### PR TITLE
Twin stacks: Two INN servers, Two FastAPI servers, Two React frontends

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,9 @@ services:
       - 1119:119
       - 1563:563
 
-  fastapi-server:
+  fastapi-server-austin:
     image: fastapi
     build:
-      # context: .
       dockerfile: Dockerfile
     environment:
       SERVER_PORT: 5001
@@ -22,9 +21,19 @@ services:
       - 5001:5001
     depends_on:
       - internetnews-server-austin
+
+  fastapi-server-boston:
+    image: fastapi
+    build:
+      dockerfile: Dockerfile
+    environment:
+      SERVER_PORT: 5001
+    ports:
+      - 5002:5001
+    depends_on:
       - internetnews-server-boston
 
-  imls-react:
+  imls-react-austin:
     image: imlsreact
     build:
       context: fe2
@@ -32,8 +41,20 @@ services:
     environment:
       NODE_ENV: development
       REACT_APP_API_URL: http://localhost:5001
-
     ports:
       - 4000:4000
     depends_on:
-      - fastapi-server
+      - fastapi-server-austin
+
+  imls-react-boston:
+    image: imlsreact
+    build:
+      context: fe2
+      dockerfile: Dockerfile
+    environment:
+      NODE_ENV: development
+      REACT_APP_API_URL: http://localhost:5002
+    ports:
+      - 4001:4001
+    depends_on:
+      - fastapi-server-boston


### PR DESCRIPTION
Docker external ports | Austin stack | Boston stack | hint
:---:|:---:|:---:|:---
InternetNews Server | 119,563 | 1119,1563 | +1,000
FastAPI Server | 5001 | 5002 | +1
React Server | 4000 | 4001 | +1



```
services:
  internetnews-server-austin:
    image: cclauss/inn
    ports:
      - 119:119
      - 563:563

  internetnews-server-boston:
    image: cclauss/inn
    ports:
      - 1119:119  # Outside port is Inside port + 1,000
      - 1563:563

  fastapi-server-austin:
    image: fastapi
    ports:
      - 5001:5001

  fastapi-server-boston:
    image: fastapi
    ports:
      - 5002:5001  # Outside port is Inside port + 1

  imls-react-austin:
    image: imlsreact
    ports:
      - 4000:4000

  imls-react-boston:
    image: imlsreact
    ports:
      - 4001:4001  # Outside port is Inside port + 1
