### PR TITLE
ruff v0.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.6
+    rev: v0.9.0
     hooks:  # Format before linting
       - id: ruff
       - id: ruff-format

--- a/demo/michigan_mashup.py
+++ b/demo/michigan_mashup.py
@@ -70,7 +70,7 @@ async def whgazetteer() -> None:
                 if func_name in url:
                     result = func(result)  # noqa: PLW2901
                     break
-            print(f"Text from {url}:\n\n{result}\n\n{'='*50}\n")
+            print(f"Text from {url}:\n\n{result}\n\n{'=' * 50}\n")
         else:
             print(f"Failed to fetch text from {url}")
 


### PR DESCRIPTION
Python stable format for 2025.  https://github.com/astral-sh/ruff/releases