### PR TITLE
Docker: imls-react-boston ports: 4001:4000

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,6 @@ services:
       NODE_ENV: development
       REACT_APP_API_URL: http://localhost:5002
     ports:
-      - 4001:4001
+      - 4001:4000
     depends_on:
       - fastapi-server-boston


### PR DESCRIPTION
```diff
imls-react-boston:
    ...
    ports:
-      - 4001:4001
+      - 4001:4000
```
% `docker compose -f docker-compose.yml up ` # Six services come up.
* http://localhost:4000/imls -- Works!
* http://localhost:4001/imls -- Does this work?!?
