### PR TITLE
docker-compose.yml: Add environment variable INN_SERVER_NAME

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     build:
       dockerfile: Dockerfile
     environment:
+      INN_SERVER_NAME: internetnews-server-austin
       SERVER_PORT: 5001
     ports:
       - 5001:5001
@@ -36,6 +37,7 @@ services:
     build:
       dockerfile: Dockerfile
     environment:
+      INN_SERVER_NAME: internetnews-server-boston
       SERVER_PORT: 5001
     ports:
       - 5002:5001

--- a/scripts/get_nntp_channels.py
+++ b/scripts/get_nntp_channels.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env -S uv run --script
+
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "pynntp",
+# ]
+# ///
+
+import os
+from collections.abc import Iterator
+
+import nntp
+
+AUSTIN_PORT = 119
+BOSTON_PORT = AUSTIN_PORT + 1000
+CLIENT: nntp.NNTPClient | None = None
+
+
+def get_nntp_client(port: int = 119) -> nntp.NNTPClient:
+    global CLIENT
+    if CLIENT:
+        return CLIENT
+
+    # Environment variable INN_SERVER_NAME is defined in the docker-compose.yml file.
+    inn_server_name = os.getenv("INN_SERVER_NAME", "localhost")
+    if port == BOSTON_PORT:  # Special case for localhost accessing Boston container.
+        inn_server_name = "localhost"
+    return (CLIENT := nntp.NNTPClient(inn_server_name, port=port))
+
+
+def channels(nntp_client: nntp.NNTPClient) -> Iterator[str]:
+    for name, description in set(nntp_client.list_newsgroups()):
+        yield f"{name=:<20}: {description=}"
+
+
+if __name__ == "__main__":
+    austin_nntp = get_nntp_client(port=119)
+    print("NNTP Server @ port 119:\n\t" + "\n\t".join(channels(austin_nntp)))
+
+    boston_nntp = get_nntp_client(port=1119)
+    print("NNTP Server @ port 1119\n\t" + "\n\t".join(channels(boston_nntp)))


### PR DESCRIPTION
Two FastAPI apps are running in two separate Docker containers.
Two INN servers are running in two separate Docker containers.
The FastAPI servers will use the environment variable INN_SERVER_NAME to connect to the corresponding INN server.

### Accessing the two INN servers:
Internally (from other containers like the FastAPI containers):
* Use `internetnews-server-austin:119`
* Use `internetnews-server-boston:119`

Externally (from your host):
* Use `localhost:119` for Austin
* Use `localhost:1119` for Boston

`host.docker.internal` would be used if the INN server was running on your localhost machine.