### PR TITLE
Workaround for `pynntp_client.list_newsgroups()`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
           - tomli
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.11
+    rev: v0.11.12
     hooks:
       - id: ruff-check
       - id: ruff-format


### PR DESCRIPTION
Workaround for:
* greenbender/pynntp#95

### Workaround: Use `client.list_active()` instead of `client.list_newsgroup()`
* But there is no way to get the `description` of newly created newsgroups.