### PR TITLE
Add version_url and spdx_license_expression to EducationResource

### DIFF
--- a/server/plugins/ome_plugin.py
+++ b/server/plugins/ome_plugin.py
@@ -26,7 +26,10 @@ class EducationResource(BaseModel):
         subject_tags: Description of subject_tags
         creation_date: Description of creation_date
         last_modified_date: Description of last_modified_date
-        usage: Description of usage
+        source_url: Permanent URL where the resource can be found
+        version_url: URL where this version of the resource can be found
+        spdx_license_expression: License using SPDX standard https://spdx.org/licenses
+        # TBD: usage: Description of usage
     """
 
     # from .pedigree_record import PedigreeRecord
@@ -39,6 +42,8 @@ class EducationResource(BaseModel):
     creation_date: datetime | None = None
     last_modified_date: datetime | None = None
     source_url: str = ""
+    version_url: str = ""
+    spdx_license_expression: str = ""
 
 
 class OMEPlugin:


### PR DESCRIPTION
@mdlama: As we discussed on today's call.
```diff
         source_url: Permanent URL where the resource can be found
+        version_url: URL where this version of the resource can be found
+        spdx_license_expression: License using the SPDX standard https://spdx.org/licenses
```
* https://spdx.org/licenses
* https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/#expression-examples
> Some examples of valid License-Expression values:
* License-Expression: MIT
* License-Expression: BSD-3-Clause
* License-Expression: MIT AND (Apache-2.0 OR BSD-2-Clause)
* License-Expression: MIT OR GPL-2.0-or-later OR (FSFUL AND BSD-2-Clause)
* License-Expression: GPL-3.0-only WITH Classpath-Exception-2.0 OR BSD-3-Clause
* License-Expression: LicenseRef-Public-Domain OR CC0-1.0 OR Unlicense
* License-Expression: LicenseRef-Proprietary
* License-Expression: LicenseRef-Custom-License
