### PR TITLE
Newsgroup rename after nntp-sync: xyz.public to ome.xyz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           enable-cache: true
       - run: uv python install  # Version from pyproject.toml project.requires-python
       # TODO(@cclauss): Remove `|| true` when tests are fixed
-      - run: uvx --with=beautifulsoup4,dateparser,httpx,pondpond,pydantic,pynntp pytest || true
+      - run: uvx --with=beautifulsoup4,dateparser,httpx,pondpond,pydantic,pynntp pytest
       - run: uv run scripts/nntp_io.py || true  # TODO(@cclauss): Remove `|| true` when that script is fixed
 
   front-end:

--- a/fe/README.md
+++ b/fe/README.md
@@ -26,7 +26,7 @@ cd fe
 npm install
 npm run dev
 ```
-http://localhost:3000 will show NNTP records in the `oer.public` channel of the NNTP server at port 119.
+http://localhost:3000 will show NNTP records in the `ome.oer` channel of the NNTP server at port 119.
 
 Docker external ports | Austin stack | Boston stack | hint
 :---:|:---:|:---:|:---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
 ]
 dependencies = [
   "fastapi[standard]>=0.115.8",
+  "pondpond",
   "pynntp>=2.0.1",
 ]
 

--- a/scripts/create_newsgroup.sh
+++ b/scripts/create_newsgroup.sh
@@ -6,7 +6,7 @@
 # `exit`  # Repeat with the other INN server(s).
 
 # Default newsgroup name
-NEWSGROUP=${1:-oer.public}
+NEWSGROUP=${1:-ome.oer}
 
 # Wait for INN server to start
 sleep 10

--- a/scripts/get_metadata_from_newsgroup.py
+++ b/scripts/get_metadata_from_newsgroup.py
@@ -36,6 +36,6 @@ def get_metadata_from_newsgroup(
 
 if __name__ == "__main__":
     for i, resource in enumerate(
-        get_metadata_from_newsgroup(newsgroup="qubes.public"), start=1
+        get_metadata_from_newsgroup(newsgroup="ome.qubes"), start=1
     ):
         print(f"{i:02d}: {resource})")

--- a/scripts/nntp_io.py
+++ b/scripts/nntp_io.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
     import os
     import sys
 
-    newsgroup = "local.test" if os.getenv("CI") else "oer.public"
+    newsgroup = "local.test" if os.getenv("CI") else "ome.oer"
     if sys.argv[1:]:
         newsgroup = sys.argv[1]
     print(f"{__file__}: {newsgroup=}")

--- a/server/main.py
+++ b/server/main.py
@@ -79,7 +79,7 @@ async def get_channel_cards(
     name: str, page: int = 1, page_size: int = 10
 ) -> list[Card]:
     """
-    http://localhost:5001/api/channel/eric.public/cards?page=2&page_size=25
+    http://localhost:5001/api/channel/ome.eric/cards?page=2&page_size=25
     """
     start = (page - 1) * page_size + 1
     end = start + page_size - 1

--- a/server/newsgroups_view.py
+++ b/server/newsgroups_view.py
@@ -40,7 +40,7 @@ async def get_channel_cards(
     name: str, page: int = 1, page_size: int = 10
 ) -> list[Card]:
     """
-    http://localhost:5001/api/channel/eric.public/cards?page=2&page_size=25
+    http://localhost:5001/api/channel/ome.eric/cards?page=2&page_size=25
     """
     start = (page - 1) * page_size + 1
     end = start + page_size - 1

--- a/server/plugins/qubes/README.md
+++ b/server/plugins/qubes/README.md
@@ -60,11 +60,11 @@ Manual method (might need to only run `newgroup` commands one, even after docker
 
 ```bash
 docker compose up
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup qubes.public"
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup eric.public"
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup oer.public"
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup openlibrary.public"
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup whg.public"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.eric"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.oer"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.openlibrary"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.qubes"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.whg"
 ```
 
 Visit http://localhost:5001/.

--- a/server/plugins/qubes/load_qubes_records_to_nntp.py
+++ b/server/plugins/qubes/load_qubes_records_to_nntp.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from nntp import NNTPClient, NNTPTemporaryError
 
 
-def nntp_pick_newsgroup(newsgroup: str = "qubes.public") -> tuple[str, ...]:
+def nntp_pick_newsgroup(newsgroup: str = "ome.qubes") -> tuple[str, ...]:
     """Pick a newsgroup to be the current default.
 
     Args:
@@ -46,7 +46,7 @@ def nntp_write(payload: dict, newsgroup: str = "") -> bool:
     headers = {
         "Subject": f"Test post to {newsgroup}",
         "From": "GitHub Actions <actions@github.com>",
-        "Newsgroups": newsgroup or "qubes.public",
+        "Newsgroups": newsgroup or "ome.qubes",
     }
     # for key in tuple(payload):
     #    if key != "id":
@@ -86,7 +86,7 @@ if __name__ == "__main__":
 
     try:
         with NNTPClient("localhost", port=119) as pynntp_client:
-            _total_first_last_group = nntp_pick_newsgroup("qubes.public")
+            _total_first_last_group = nntp_pick_newsgroup("ome.qubes")
             for record in records:
                 try:
                     nntp_write(record)

--- a/server/utils.py
+++ b/server/utils.py
@@ -138,7 +138,7 @@ def post_to_details(post: Post) -> ResourceDetailData:
         thumbnail=None,
         timestamp=post.date,
         updatedDate=post.date,
-        detailURL=f"/api/imls/v2/resources/qubes.public/materials/{post.id}",
+        detailURL=f"/api/imls/v2/resources/ome.qubes/materials/{post.id}",
         grade_sublevel=["High School"],
         accessibility=[],
         rating=0,

--- a/tests/test_ome_node.py
+++ b/tests/test_ome_node.py
@@ -37,6 +37,7 @@ def enable_a_default_newsgroup(newsgroup: str = "local.test") -> Generator[None]
 
 
 @pytest.mark.parametrize("port", [AUSTIN_PORT, BOSTON_PORT])
+@pytest.mark.xfail(reason="ome_node.get_client() was removed", strict=True)
 def test_pynntp_client(port: int) -> None:
     pynntp_client = ome_node.get_client(port=port)
     assert isinstance(pynntp_client, ome_node.NNTPClient)
@@ -51,6 +52,7 @@ def test_pynntp_client(port: int) -> None:
     )
 
 
+@pytest.mark.xfail(reason="ome_node.get_client() was removed.", strict=True)
 def test_channels() -> None:
     """
     Ensure that the default channels are all disabled.
@@ -59,6 +61,7 @@ def test_channels() -> None:
 
 
 @pytest.mark.usefixtures("enable_a_default_newsgroup")
+@pytest.mark.xfail(reason="enable_a_default_newsgroup() is broken.", strict=True)
 def test_one_channel() -> None:
     """
     Let's enable the channel 'local.test' so we can use it for the remaining tests.
@@ -69,6 +72,7 @@ def test_one_channel() -> None:
 
 
 @pytest.mark.usefixtures("enable_a_default_newsgroup")
+@pytest.mark.xfail(reason="ome_node.get_client() was removed.", strict=True)
 def test_channel_summary() -> None:
     nntp_client = ome_node.get_client()
     for channel in ome_node.channels():
@@ -202,13 +206,13 @@ def test_utils_get_channels(metadata: schemas.Metadata) -> None:
     channels = list(utils.get_channels())
     assert len(channels) == 5
     slug, description, plugin = channels[0]
-    assert slug == "eric.public"
+    assert slug == "ome.eric"
     assert description == (
         "Metadata from US DoE's Education Resources Information Center (ERIC) "
         "https://eric.ed.gov"
     )
     assert plugin.mimetypes == ("application/vnd.eric.eric+json",)
-    assert dict(plugin.newsgroups) == {"eric.public": description}
+    assert dict(plugin.newsgroups) == {"ome.eric": description}
     assert plugin.site_name == "Generic OME Library"
     assert plugin.librarian_contact == "info@iskme.org"
     assert plugin.logo
@@ -218,13 +222,13 @@ def test_utils_get_channels_filters() -> None:
     channels = list(utils.get_channels())
     assert len(channels) == 5
     slug, description, plugin = channels[0]
-    assert slug == "eric.public"
+    assert slug == "ome.eric"
     assert description == (
         "Metadata from US DoE's Education Resources Information Center (ERIC) "
         "https://eric.ed.gov"
     )
     assert plugin.mimetypes == ("application/vnd.eric.eric+json",)
-    assert dict(plugin.newsgroups) == {"eric.public": description}
+    assert dict(plugin.newsgroups) == {"ome.eric": description}
     assert plugin.site_name == "Generic OME Library"
     assert plugin.librarian_contact == "info@iskme.org"
 

--- a/tools/monkeyscript/OERCommons.tampermonkey_script.js
+++ b/tools/monkeyscript/OERCommons.tampermonkey_script.js
@@ -28,7 +28,7 @@ $(function() {
 
         var data = {
             "channels": [
-                "oer.public",
+                "ome.oer",
             ],
             "subject": meta["title"],
             "body": meta


### PR DESCRIPTION
Changes like:
```diff
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup eric.public"
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup oer.public"
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup openlibrary.public"
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup qubes.public"
-docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup whg.public"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.eric"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.oer"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.openlibrary"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.qubes"
+docker exec -it ome-internetnews-server-austin-1 sh -c "ctlinnd newgroup ome.whg"
```