### PR TITLE
pytest-run-parallel --iteration=8 --parallel-threads=auto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           enable-cache: true
       - run: uv python install  # Version from pyproject.toml project.requires-python
       # TODO(@cclauss): Remove `|| true` when tests are fixed
-      - run: uvx --with=beautifulsoup4,dateparser,httpx,pondpond,pydantic,pynntp pytest
+      - run: uvx --with=beautifulsoup4,dateparser,httpx,pondpond,pydantic,pynntp,pytest-run-parallel pytest --iterations=8 --parallel-threads=auto --ignore-gil-enabled
       - run: uv run scripts/nntp_io.py
 
   front-end:


### PR DESCRIPTION
https://github.com/Quansight-Labs/pytest-run-parallel
* https://py-free-threading.github.io
* https://www.python.org/downloads/release/python-3140/

Unfortunately, we need to run `pytest --ignore-gil-enabled` because of:
`pondpond` -->
* ikegami-yukino/madoka-python#14

```
 ============================= test session starts ==============================
platform linux -- Python 3.14.0, pytest-8.4.2, pluggy-1.6.0
rootdir: /home/runner/work/Open-Metadata-Exchange/Open-Metadata-Exchange
configfile: pyproject.toml
plugins: anyio-4.11.0, run-parallel-0.7.1
collected 60 items
Collected 60 items to run in parallel

tests/test_nntp_article.py ····                                          [  6%]
tests/test_ome_node.py ·xxx·························s··················· [ 88%]
·······                                                                  [100%]
************************** pytest-run-parallel report **************************
All tests were run in parallel! 🎉

================== 56 passed, 1 skipped, 3 xfailed in 13.57s ===================
```