### PR TITLE
Run shellcheck in GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  shellcheck:
+    runs-on: ubuntu-slim
+    steps:  # See configuration in .shellcheckrc
+    - uses: actions/checkout@v6
+    - run: find . -type f -name "*.sh" -exec shellcheck {} +
+
   # inn-docker:
   #  strategy:
   #    fail-fast: false

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,9 @@
+# https://www.shellcheck.net -- 'shellcheck --help'
+# https://github.com/koalaman/shellcheck
+# 'find . -type f -name "*.sh" -exec shellcheck {} +'
+
+# To improve our code quality, comment out one for the following and create a pull request:
+disable=SC1091  # 1 instance
+disable=SC2086  # 5 instances
+disable=SC2181  # 1 instance
+disable=SC2231  # Many instances


### PR DESCRIPTION
### https://github.com/koalaman/shellcheck

`shellcheck` is [preinstalled](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md#installed-apt-packages) on GitHub Actions runners.

### How was this tested?

Compare the results of:
% `find . -type f -name "*.sh" -exec shellcheck {} +`
with this GitHub Action job to ensure they match when modifying the config file `.shellcheckrc`.