### PR TITLE
fix: P0 security & reliability — CORS, NNTP creds, pool cleanup, real pagination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# ---------------------------------------------------------------------------
+# Open Metadata Exchange — example environment configuration
+# ---------------------------------------------------------------------------
+# Copy this file to `.env` for local development. Docker Compose reads
+# `.env` automatically. DO NOT commit your real `.env`.
+#
+# Every variable below is read by `server/` modules at runtime. Where
+# a sensible dev default exists, it is documented inline.
+
+# --- NNTP / INN server -----------------------------------------------------
+# Hostname of the INN server the FastAPI container talks to. Inside
+# docker-compose this is the service name (`nntp-server`); on the host
+# it is typically `localhost`.
+INN_SERVER_NAME=localhost
+
+# Port is optional; defaults to 119 if unset.
+# INN_PORT=119
+
+# INN credentials. REQUIRED — there is no hardcoded fallback. See
+# `server/connection_pool.py`. In docker-compose these default to the
+# values preseeded by `server_config/news_server`.
+INN_USERNAME=node
+INN_PASSWORD=node
+
+# --- CORS / deployment environment ----------------------------------------
+# Any value other than `prod` activates dev behavior: wildcard origins
+# are tolerated, and `OME_ALLOWED_ORIGINS` may be omitted (localhost
+# defaults are used). In prod both guards are strict.
+OME_ENV=dev
+
+# Comma-separated list of origins allowed by the FastAPI CORS
+# middleware. Required in prod. Wildcards (`*`) are forbidden in prod.
+# OME_ALLOWED_ORIGINS=https://ome.example.org,https://admin.example.org
+
+# --- FastAPI server --------------------------------------------------------
+# Port the FastAPI app listens on.
+SERVER_PORT=5001
+
+# --- Plugin selection ------------------------------------------------------
+# Dotted path to the OME plugin class this node hosts. See
+# `server/get_ome_plugins.py`.
+CMS_PLUGIN=server.plugins.qubes.plugin.QubesPlugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,14 @@ jobs:
         with:
           enable-cache: true
       - run: uv python install  # Version from pyproject.toml project.requires-python
-      # TODO(@cclauss): Remove `|| true` when tests are fixed
-      - run: uvx --with=beautifulsoup4,dateparser,httpx,pondpond,pydantic,pynntp,pytest-run-parallel pytest --iterations=8 --parallel-threads=auto --ignore-gil-enabled
+      # NNTP credentials and CORS config required by server.connection_pool
+      # and server.config — see .env.example.
+      - name: Run pytest
+        env:
+          INN_USERNAME: node
+          INN_PASSWORD: node
+          OME_ENV: dev
+        run: uvx --with=beautifulsoup4,dateparser,httpx,pondpond,pydantic,pynntp,pytest-run-parallel pytest --iterations=8 --parallel-threads=auto --ignore-gil-enabled
       - run: uv run scripts/nntp_io.py
 
   front-end:

--- a/docker-compose-two-hosts.yml
+++ b/docker-compose-two-hosts.yml
@@ -45,6 +45,10 @@ services:
     environment:
       CMS_PLUGIN: server.plugins.qubes.plugin.QubesPlugin
       INN_SERVER_NAME: 10.0.0.94 # austin
+      INN_USERNAME: ${INN_USERNAME:-node}
+      INN_PASSWORD: ${INN_PASSWORD:-node}
+      OME_ENV: ${OME_ENV:-dev}
+      OME_ALLOWED_ORIGINS: ${OME_ALLOWED_ORIGINS:-}
       SERVER_PORT: 5001
     ports:
       - 5001:5001
@@ -62,6 +66,10 @@ services:
     environment:
       CMS_PLUGIN: server.plugins.oercommons.plugin.OERCommonsPlugin
       INN_SERVER_NAME: 10.0.0.130 # boston
+      INN_USERNAME: ${INN_USERNAME:-node}
+      INN_PASSWORD: ${INN_PASSWORD:-node}
+      OME_ENV: ${OME_ENV:-dev}
+      OME_ALLOWED_ORIGINS: ${OME_ALLOWED_ORIGINS:-}
       SERVER_PORT: 5001
     ports:
       - 5002:5001

--- a/docker-compose-virtual-box.yml
+++ b/docker-compose-virtual-box.yml
@@ -45,6 +45,10 @@ services:
     environment:
       CMS_PLUGIN: server.plugins.qubes.plugin.QubesPlugin
       INN_SERVER_NAME: 10.0.0.94 # austin
+      INN_USERNAME: ${INN_USERNAME:-node}
+      INN_PASSWORD: ${INN_PASSWORD:-node}
+      OME_ENV: ${OME_ENV:-dev}
+      OME_ALLOWED_ORIGINS: ${OME_ALLOWED_ORIGINS:-}
       SERVER_PORT: 5001
     ports:
       - 5001:5001
@@ -62,6 +66,10 @@ services:
     environment:
       CMS_PLUGIN: server.plugins.oercommons.plugin.OERCommonsPlugin
       INN_SERVER_NAME: 10.0.0.130 # boston
+      INN_USERNAME: ${INN_USERNAME:-node}
+      INN_PASSWORD: ${INN_PASSWORD:-node}
+      OME_ENV: ${OME_ENV:-dev}
+      OME_ALLOWED_ORIGINS: ${OME_ALLOWED_ORIGINS:-}
       SERVER_PORT: 5001
     ports:
       - 5002:5001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,15 @@ services:
     environment:
       CMS_PLUGIN: server.plugins.qubes.plugin.QubesPlugin
       INN_SERVER_NAME: nntp-server
-      # TODO: need to add the username/password that the NNTP server
-      # now needs via .env or some such
+      # NNTP credentials are required (no hardcoded fallback — see
+      # server/connection_pool.py and .env.example). These match the
+      # users preseeded by server_config/news_server.
+      INN_USERNAME: ${INN_USERNAME:-node}
+      INN_PASSWORD: ${INN_PASSWORD:-node}
+      # CORS allow-list for the FastAPI server. In prod this must be
+      # set to an explicit list; dev defaults cover localhost.
+      OME_ENV: ${OME_ENV:-dev}
+      OME_ALLOWED_ORIGINS: ${OME_ALLOWED_ORIGINS:-}
       SERVER_PORT: 5001
     networks:
       my_network:

--- a/docs/changes/p0-security-reliability.md
+++ b/docs/changes/p0-security-reliability.md
@@ -1,0 +1,153 @@
+# P0 security & reliability fixes — branch `fix/p0-security-reliability`
+
+Resolves issues
+[#1](https://github.com/jsgoecke/Open-Metadata-Exchange/issues/1),
+[#2](https://github.com/jsgoecke/Open-Metadata-Exchange/issues/2),
+[#3](https://github.com/jsgoecke/Open-Metadata-Exchange/issues/3),
+[#4](https://github.com/jsgoecke/Open-Metadata-Exchange/issues/4).
+
+All fixes were implemented with TDD: failing test first, minimal
+implementation second, then refactor. Full offline unit test coverage
+has been added for each fix.
+
+## Summary of behavior changes
+
+| Area | Before | After |
+|---|---|---|
+| CORS | `allow_origins=["*"]` hardcoded | Env-driven via `OME_ALLOWED_ORIGINS`; wildcards forbidden when `OME_ENV=prod` |
+| NNTP credentials | Hardcoded `username="node"`, `password="node"` | Required env vars `INN_USERNAME` / `INN_PASSWORD`; missing → `MissingNNTPCredentialsError` |
+| Connection pool on error | `__exit__` silently recycled broken connections | Broken connections are destroyed via `factory.destroy`; only clean exits are recycled |
+| API pagination metadata | Hardcoded `total_num_articles=124`, `page=1` | Real count aggregated from `channel_summary().estimated_total_articles`; `page` query parameter is honored |
+| Fabricated detail fields | `source`, `grade_sublevel`, `license`, `visits` shipped hardcoded fake values | Honest defaults (`""` / `[]` / `0`) until real metadata sources are plumbed through (see follow-up TODO in `server/utils.py::post_to_details`) |
+
+## Issue-by-issue
+
+### #1 — CORS allow-list (`server/config.py`, `server/main.py`, `server/newsgroups_view.py`)
+
+New module `server/config.py` exposes:
+
+- `get_allowed_origins() -> list[str]`
+- `get_cors_middleware_kwargs() -> dict[str, Any]`
+- `is_production() -> bool`
+- `InvalidCORSConfigError`
+
+`OME_ALLOWED_ORIGINS` is parsed as a comma-separated list with
+whitespace trimming and empty-entry drop. In production
+(`OME_ENV=prod`) the variable is required and must not contain `*`.
+Otherwise a small localhost allow-list is used by default.
+
+`main.py` and `newsgroups_view.py` now register the middleware with
+`**get_cors_middleware_kwargs()` — no more wildcard.
+
+Tests: `tests/test_p0_config.py` (7 cases) plus endpoint-level
+verification in `tests/test_p0_main_endpoints.py`.
+
+### #2 — NNTP credentials from environment (`server/connection_pool.py`)
+
+The `"node" / "node"` strings are gone. `ClientFactory.createInstance`
+calls `_require_env("INN_USERNAME")` / `_require_env("INN_PASSWORD")`;
+missing or empty values raise `MissingNNTPCredentialsError` — we fail
+fast rather than substitute a default.
+
+`INN_PORT` is now honored too (default 119).
+
+Tests: `tests/test_p0_connection_pool.py::test_client_factory_*` (4
+cases).
+
+### #3 — Remove hardcoded mock data (`server/utils.py`, `server/main.py`)
+
+- `post_to_details` no longer emits fabricated `source`,
+  `grade_sublevel`, `license`, or `visits` values. It returns
+  conservative empty/zero defaults with a `TODO` pointing at the
+  followup work (extending the plugin metadata schema to carry these
+  fields).
+- `browse_results` now computes `total_num_articles` via
+  `_total_articles_across_channels()` which sums
+  `channel_summary(slug).estimated_total_articles` across every
+  plugin-registered channel.
+- `get_channel_resources` uses the per-channel
+  `channel_summary(slug).estimated_total_articles` directly.
+- `get_channel_summary` replaces `numResources=100` and the
+  fabricated `educationLevels` list with the real NNTP count and an
+  empty list respectively.
+- `browse_results` and `get_channel_resources` now accept and return a
+  `page` parameter. The endpoint signatures in `main.py` expose
+  `page` as a query parameter.
+
+**Scope note:** physically skipping the first N·per_page articles at
+the NNTP layer (i.e. fetching page 3 of `articles` rather than the
+latest N regardless of page) is a follow-up; the underlying
+`ome_node.get_last_n_posts` API does not take an offset. The
+pagination *metadata* returned to the client is now real, which
+addresses the primary correctness bug. See TODO in
+`server/utils.py::browse_results`.
+
+Tests: `tests/test_p0_utils.py` (7 cases), endpoint wiring in
+`tests/test_p0_main_endpoints.py` (5 cases).
+
+### #4 — Connection pool `__exit__` cleanup (`server/connection_pool.py`)
+
+`ClientContextManager.__exit__` now:
+
+- Takes properly-typed exception parameters (`type[BaseException] |
+  None`, `BaseException | None`, `TracebackType | None`).
+- On clean exit: returns the pooled object to the pool via
+  `pond.recycle`.
+- On *any* exception: destroys the pooled object via
+  `factory.destroy` — we cannot prove the connection is healthy after
+  a failure, so we drop it conservatively.
+- Returns `False` so exceptions always propagate.
+
+`factory.destroy` now also best-effort closes the underlying client
+via `client.quit()`.
+
+Tests: `tests/test_p0_connection_pool.py::test_context_manager_*` (5
+cases).
+
+## Test infrastructure
+
+`tests/conftest.py` is new and does two things:
+
+1. Detects whether port 119 on `INN_SERVER_NAME` is reachable. If not,
+   it monkeypatches `nntp.NNTPClient.__init__` to a no-op so modules
+   that eagerly register an NNTP connection at import time can be
+   imported in offline unit tests. CI unaffected — the INN service
+   container is reachable, so no stub is installed.
+2. When stubbed, auto-skips the integration tests in
+   `tests/test_ome_node.py` (which hit a real INN server) to keep the
+   offline suite green.
+
+Defaults for `INN_USERNAME`, `INN_PASSWORD`, and `INN_SERVER_NAME` are
+set so the new env-required code paths don't explode during local
+collection.
+
+## Running the tests
+
+Offline (no INN server needed):
+
+```bash
+uv run pytest
+# expected: ~55 passed, 56 skipped
+```
+
+Full integration (requires a reachable INN server on port 119):
+
+```bash
+docker compose up -d nntp-server
+INN_USERNAME=node INN_PASSWORD=node OME_ENV=dev uv run pytest
+```
+
+CI runs the integration mode via the `inn-service` container in
+`.github/workflows/ci.yml`.
+
+## Migration notes for deployers
+
+- Set `INN_USERNAME` and `INN_PASSWORD` on every environment that
+  runs the FastAPI server, or it will refuse to start. The supplied
+  `docker-compose*.yml` files inject sensible defaults that match the
+  preseeded INN users.
+- Set `OME_ENV=prod` and `OME_ALLOWED_ORIGINS=<csv>` on production
+  deployments. Anything else will raise `InvalidCORSConfigError`
+  at startup — by design.
+- Review `.env.example` for the full list of supported environment
+  variables.

--- a/server/config.py
+++ b/server/config.py
@@ -1,0 +1,107 @@
+"""Runtime configuration helpers for the OME server.
+
+Today this module only holds CORS configuration; keep it small and
+focused. Add new config helpers here as we continue retiring hardcoded
+defaults scattered across the codebase.
+
+Environment variables
+---------------------
+``OME_ENV``
+    Either ``prod`` or anything else. Only ``prod`` activates the
+    strict guards (wildcard refusal, required env vars).
+
+``OME_ALLOWED_ORIGINS``
+    Comma-separated list of origins permitted by the FastAPI CORS
+    middleware. Whitespace around entries is trimmed and empty entries
+    are dropped. In production this must be set and must not be a
+    wildcard. See :func:`get_allowed_origins`.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+__all__ = [
+    "InvalidCORSConfigError",
+    "get_allowed_origins",
+    "get_cors_middleware_kwargs",
+    "is_production",
+]
+
+# Dev defaults match the local front-end (webpack dev server + static
+# mount) and the current Dockerfile EXPOSE values. Kept intentionally
+# small.
+_DEV_DEFAULT_ORIGINS: tuple[str, ...] = (
+    "http://localhost:3000",
+    "http://localhost:5001",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:5001",
+)
+
+
+class InvalidCORSConfigError(RuntimeError):
+    """Raised when CORS configuration is unsafe for the current env."""
+
+
+def is_production() -> bool:
+    """True when ``OME_ENV=prod``. Anything else is treated as dev/test."""
+    return os.environ.get("OME_ENV", "").strip().lower() == "prod"
+
+
+def _parse_csv(raw: str) -> list[str]:
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def get_allowed_origins() -> list[str]:
+    """Return the CORS allow-list for this process.
+
+    Resolution order:
+
+    1. ``OME_ALLOWED_ORIGINS`` env var, comma-separated.
+    2. In dev only: a small hardcoded localhost default list.
+
+    In production the env var is **required** and may not contain a
+    ``*`` wildcard. Violations raise :class:`InvalidCORSConfigError`
+    so misconfiguration fails at startup rather than silently
+    exposing the API.
+    """
+    raw = os.environ.get("OME_ALLOWED_ORIGINS", "")
+    prod = is_production()
+
+    if not raw.strip():
+        if prod:
+            msg = (
+                "OME_ALLOWED_ORIGINS must be set when OME_ENV=prod. "
+                "Provide a comma-separated list of allowed origins "
+                "(e.g. https://ome.example.org)."
+            )
+            raise InvalidCORSConfigError(msg)
+        return list(_DEV_DEFAULT_ORIGINS)
+
+    origins = _parse_csv(raw)
+
+    if prod and any(o == "*" for o in origins):
+        msg = (
+            "OME_ALLOWED_ORIGINS contains a wildcard '*' but OME_ENV=prod. "
+            "Wildcards are forbidden in production — list explicit "
+            "origins instead."
+        )
+        raise InvalidCORSConfigError(msg)
+
+    return origins
+
+
+def get_cors_middleware_kwargs() -> dict[str, Any]:
+    """Kwargs suitable for ``FastAPI.add_middleware(CORSMiddleware, ...)``.
+
+    Credentials stay disabled; enable only if and when a credentialed
+    flow is introduced — and at that point wildcards become illegal
+    per the CORS spec anyway.
+    """
+    return {
+        "allow_origins": get_allowed_origins(),
+        "allow_credentials": False,
+        "allow_methods": ["GET", "POST", "OPTIONS"],
+        "allow_headers": ["*"],
+    }

--- a/server/connection_pool.py
+++ b/server/connection_pool.py
@@ -1,42 +1,111 @@
+"""NNTP connection pool for the OME server.
+
+Provides a small ``pond``-backed pool of ``pynntp.NNTPClient`` instances
+and a context manager (``ClientContextManager``) that borrows / returns
+them.
+
+Security notes
+--------------
+Credentials are **never** hardcoded. ``INN_USERNAME`` and
+``INN_PASSWORD`` must be present in the environment (see
+``.env.example`` for local development, and the ``docker-compose.yml``
+service definition for the ``inn`` container defaults). Missing or
+empty values raise :class:`MissingNNTPCredentialsError` at connection
+time — we fail fast rather than silently substitute a default.
+
+Reliability notes
+-----------------
+If any exception is raised inside ``with ClientContextManager() as c:``,
+the pooled connection is *destroyed* (via ``factory.destroy``) rather
+than ``recycle``d back into the pool. The connection's state after an
+error is unknown, and returning it to the pool would let the next
+caller inherit a broken socket.
+"""
+
+from __future__ import annotations
+
 import os
+from types import TracebackType
 
 from nntp import NNTPClient, NNTPError
 from pond import Pond, PooledObject, PooledObjectFactory
 
 
+class MissingNNTPCredentialsError(RuntimeError):
+    """Raised when required NNTP credential env vars are missing or empty.
+
+    This is fatal and intentional: we refuse to fall back to a hardcoded
+    default, because that is exactly the bug issue #2 exists to fix.
+    """
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        msg = (
+            f"Required environment variable {name!r} is not set. "
+            "NNTP credentials must be provided via INN_USERNAME and "
+            "INN_PASSWORD — there is no hardcoded fallback. "
+            "See .env.example."
+        )
+        raise MissingNNTPCredentialsError(msg)
+    return value
+
+
 class ClientFactory(PooledObjectFactory):
-    def createInstance(self) -> PooledObject:  # noqa: N802
-        # Environment variable INN_SERVER_NAME is defined in docker-compose.yml file.
+    """Creates ``pynntp.NNTPClient`` instances for the pool.
+
+    Reads connection parameters from the environment on *each* call to
+    ``createInstance`` so tests and long-running processes pick up
+    rotated credentials without a restart:
+
+    * ``INN_SERVER_NAME`` — hostname of the INN server (default
+      ``localhost``).
+    * ``INN_PORT`` — optional override, defaults to 119.
+    * ``INN_USERNAME`` / ``INN_PASSWORD`` — required, no default.
+    """
+
+    def createInstance(self) -> PooledObject:  # noqa: N802 — pond API
         inn_server_name = os.getenv("INN_SERVER_NAME", "localhost")
-        port = 119
+        port = int(os.getenv("INN_PORT", "119"))
+        username = _require_env("INN_USERNAME")
+        password = _require_env("INN_PASSWORD")
         client = NNTPClient(
             inn_server_name,
             port=port,
-            username="node",
-            password="node",  # noqa: S106
+            username=username,
+            password=password,
         )
         return PooledObject(client)
 
     def destroy(self, pooled_object: PooledObject) -> None:
+        """Release the client's socket as the pool drops the object."""
+        try:
+            client = pooled_object.keeped_object
+            quit_ = getattr(client, "quit", None)
+            if callable(quit_):
+                quit_()
+        except (NNTPError, OSError):
+            # Best-effort close; if the connection is already dead, so
+            # be it — we're about to discard the object anyway.
+            pass
         del pooled_object
 
     def reset(self, pooled_object: PooledObject) -> PooledObject:
-        # do whatever we need to do for resetting a connection.
-        # e.g. commit or abort a transaction, in the case of an RDBMS.
+        # Whatever per-use reset is needed would live here. NNTP is
+        # mostly stateless per command so there's nothing to undo.
         return pooled_object
 
     def validate(self, pooled_object: PooledObject) -> bool:
-        # test the connection and validate it's working
+        """Return True if the underlying connection still responds.
+
+        Pond calls this before handing a pooled object to a borrower; a
+        False return causes pond to discard the object.
+        """
         con = pooled_object.keeped_object
         try:
-            # TODO(@aa-iskme): is there a way to check the con.socket.fd
-            # to see if the connection is closed? This is good for now
-            # but would be nice if we didn't have to issue a command to
-            # the NNTP server to check if the connection is still
-            # active.
-            _dd = con.date()
+            con.date()
         except NNTPError:
-            # Connections isn't usable anymore.
             return False
         return True
 
@@ -53,13 +122,28 @@ pond.register(factory)
 
 
 class ClientContextManager:
+    """Borrow an NNTP client for the duration of a ``with`` block.
+
+    On clean exit the client is recycled back into the pool. If any
+    exception escapes the block, the client is **destroyed** instead —
+    see module docstring for the rationale.
+    """
+
     def __enter__(self) -> NNTPClient:
         self.pooled = pond.borrow(factory)
         return self.pooled.use()
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # noqa: ANN001
-        if exc_type:
-            # Exception occurred. Check to see if it's a connection
-            # related exception. Then delete the connection.
-            pass
-        pond.recycle(self.pooled, factory)
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool:
+        if exc_type is None:
+            pond.recycle(self.pooled, factory)
+        else:
+            # Connection state is unknown after any exception. Do NOT
+            # return it to the pool; destroy it so the next borrower
+            # gets a fresh client.
+            factory.destroy(self.pooled)
+        return False  # never suppress exceptions

--- a/server/main.py
+++ b/server/main.py
@@ -139,9 +139,7 @@ async def get_channel(
     sortby: str = "timestamp",
     page: int = 1,
 ) -> ChannelResourcesResponse:
-    return get_channel_resources(
-        channel, per_page=per_page, sortby=sortby, page=page
-    )
+    return get_channel_resources(channel, per_page=per_page, sortby=sortby, page=page)
 
 
 @app.get("/api/imls/v2/resources/")
@@ -151,9 +149,7 @@ async def get_resources(
     sortby: str = "timestamp",
     page: int = 1,
 ) -> ChannelResourcesResponse:
-    return get_channel_resources(
-        tenant, per_page=per_page, sortby=sortby, page=page
-    )
+    return get_channel_resources(tenant, per_page=per_page, sortby=sortby, page=page)
 
 
 app.mount(

--- a/server/main.py
+++ b/server/main.py
@@ -8,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from server import ome_node
+from server.config import get_cors_middleware_kwargs
 from server.helpers import MocAPI
 from server.schemas import (
     Attachment,
@@ -33,13 +34,7 @@ unused = httpx
 
 app = FastAPI()
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+app.add_middleware(CORSMiddleware, **get_cors_middleware_kwargs())
 
 
 @app.get("/channels", response_class=HTMLResponse)
@@ -118,8 +113,12 @@ async def import_post(name: str, card: CardRef) -> bool:
 
 
 @app.get("/api/imls/v2/collections/browse/")
-async def browse(sortby: str = "timestamp", per_page: int = 10) -> BrowseResponse:
-    return browse_results(sortby, per_page)
+async def browse(
+    sortby: str = "timestamp",
+    per_page: int = 10,
+    page: int = 1,
+) -> BrowseResponse:
+    return browse_results(sortby=sortby, per_page=per_page, page=page)
 
 
 @app.get("/api/imls/v2/explore-oer-exchange/")
@@ -133,13 +132,28 @@ async def channel_summary(channel: str, _id: int) -> ChannelSummaryResponse:
 
 
 @app.get("/api/imls/v2/collections/{channel}/{_id}/resources")
-async def get_channel(channel: str, _id: int) -> ChannelResourcesResponse:
-    return get_channel_resources(channel)
+async def get_channel(
+    channel: str,
+    _id: int,
+    per_page: int = 10,
+    sortby: str = "timestamp",
+    page: int = 1,
+) -> ChannelResourcesResponse:
+    return get_channel_resources(
+        channel, per_page=per_page, sortby=sortby, page=page
+    )
 
 
 @app.get("/api/imls/v2/resources/")
-async def get_resources(tenant: str) -> ChannelResourcesResponse:
-    return get_channel_resources(tenant)
+async def get_resources(
+    tenant: str,
+    per_page: int = 10,
+    sortby: str = "timestamp",
+    page: int = 1,
+) -> ChannelResourcesResponse:
+    return get_channel_resources(
+        tenant, per_page=per_page, sortby=sortby, page=page
+    )
 
 
 app.mount(

--- a/server/newsgroups_view.py
+++ b/server/newsgroups_view.py
@@ -5,18 +5,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from server import ome_node
+from server.config import get_cors_middleware_kwargs
 from server.helpers import MocAPI
 from server.schemas import Card, CardRef, Channel, ChannelSummary, NewCard
 
 app = FastAPI()
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=False,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+app.add_middleware(CORSMiddleware, **get_cors_middleware_kwargs())
 
 # If we are not running in Continuous Integration then enable the INN local.test group.
 if not os.getenv("CI"):  # Not running in Continuous Integration

--- a/server/utils.py
+++ b/server/utils.py
@@ -128,40 +128,77 @@ def post_to_summary(post: Post) -> ResourceSummaryData:
 
 
 def post_to_details(post: Post) -> ResourceDetailData:
+    """Map an NNTP :class:`Post` to the IMLS detail-view schema.
+
+    Previously this function shipped fabricated constants (``source``,
+    ``grade_sublevel``, ``license``, ``visits`` etc.) to every response.
+    Consumers treating those as real data received wrong answers. Until
+    real metadata sources for those fields exist, we emit honest
+    "unknown" values (empty string / empty list / 0). See issue #3.
+
+    TODO(#3-followup): source these fields from plugin-provided
+    metadata once the plugin schema is extended.
+    """
     return ResourceDetailData(
         id=post.id,
         title=post.subject,
         abstract=post.body,
-        source="Course Related Material",
+        source="",
         url=None,
         metadata=[],
         thumbnail=None,
         timestamp=post.date,
         updatedDate=post.date,
-        detailURL=f"/api/imls/v2/resources/ome.qubes/materials/{post.id}",
-        grade_sublevel=["High School"],
+        detailURL=f"/api/imls/v2/resources/{post.channels[0]}/materials/{post.id}",
+        grade_sublevel=[],
         accessibility=[],
         rating=0,
         ratings_number=0,
         site=post.channels[0],
-        license="educational-use-permitted",
-        license_cou_bucket="read-the-fine-print",
-        license_types=["read-the-fine-print", "educational-use-permitted"],
-        license_bucket_title="Read the Fine Print",
-        visits=22,
+        license="",
+        license_cou_bucket="",
+        license_types=[],
+        license_bucket_title="",
+        visits=0,
         collections=post.channels,
     )
 
 
-def browse_results(sortby: str = "timestamp", per_page: int = 10) -> BrowseResponse:
+def _total_articles_across_channels() -> int:
+    """Sum :class:`ChannelSummary.estimated_total_articles` for every
+    channel in the plugin registry. Replaces the old hardcoded ``124``.
+    """
+    return sum(
+        channel_summary(slug).estimated_total_articles
+        for slug, _description, _plugin in get_channels()
+    )
+
+
+def browse_results(
+    sortby: str = "timestamp",
+    per_page: int = 10,
+    page: int = 1,
+) -> BrowseResponse:
+    """Cross-channel browse response for the IMLS API.
+
+    Pagination metadata now reflects real values aggregated from NNTP
+    channel summaries rather than the previous hardcoded constants.
+    The ``page`` parameter is threaded through from the endpoint.
+
+    Item-level pagination (fetching the Nth page of merged articles)
+    is not yet implemented at the NNTP layer; the list currently
+    shows the latest ``per_page`` articles regardless of ``page``.
+    See issue #3 follow-up.
+    """
     plugin = site_plugin
-    total_num_articles = 124
-    plugin_by_slug = {slug: plugin for slug, _description, plugin in get_channels()}
+    total_num_articles = _total_articles_across_channels()
+    plugin_by_slug = {slug: p for slug, _description, p in get_channels()}
     latest = [post_to_summary(x) for x in get_latest_articles(per_page)]
     for item in latest:
         item.thumbnail = plugin_by_slug[item.micrositeSlug].logo
 
     tenant_slug = next(iter(plugin.newsgroups.keys()))
+    num_pages = max(1, math.ceil(total_num_articles / per_page)) if per_page else 1
     return BrowseResponse(
         collections=Collections(
             items=latest,
@@ -171,11 +208,9 @@ def browse_results(sortby: str = "timestamp", per_page: int = 10) -> BrowseRespo
             sortBy=sortby,
             sortByOptions=sort_options,
             pagination=PaginationOptions(
-                count=total_num_articles,  # TODO(anooparyal): get the
-                # total count of articles
-                # available
-                numPages=math.ceil(total_num_articles / per_page),
-                page=1,
+                count=total_num_articles,
+                numPages=num_pages,
+                page=page,
                 perPage=per_page,
                 perPageOptions=[10, 30, 50],
             ),
@@ -198,10 +233,17 @@ def browse_results(sortby: str = "timestamp", per_page: int = 10) -> BrowseRespo
 def get_channel_summary(
     channel_slug: str, _per_page: int = 3, _sortby: str = "timestamp"
 ) -> ChannelSummaryResponse:
+    """Per-channel summary for the IMLS API.
+
+    Real values from NNTP (estimated article count) now replace the
+    previously hardcoded ``numResources=100`` and fabricated
+    ``educationLevels`` list. See issue #3.
+    """
     plugin = site_plugin
-    plugin_by_slug = {slug: plugin for slug, _description, plugin in get_channels()}
+    plugin_by_slug = {slug: p for slug, _description, p in get_channels()}
 
     channel_plugin = plugin_by_slug[channel_slug]
+    num_resources = channel_summary(channel_slug).estimated_total_articles
 
     tenant_slug = next(iter(plugin.newsgroups.keys()))
     return ChannelSummaryResponse(
@@ -210,15 +252,11 @@ def get_channel_summary(
             name="",
             abstract="",
             isShared=True,
-            educationLevels=[
-                "College / Upper Division",
-                "Community College / Lower Division",
-                "High School",
-            ],
+            educationLevels=[],
             micrositeName=channel_plugin.site_name,
             micrositeSlug=channel_slug,
             numAlerts=0,
-            numResources=100,
+            numResources=num_resources,
             numSubscribers=0,
             subscribed=False,
             thumbnail=channel_plugin.logo,
@@ -233,16 +271,26 @@ def get_channel_summary(
 
 
 def get_channel_resources(
-    channel_slug: str, per_page: int = 10, sortby: str = "timestamp"
+    channel_slug: str,
+    per_page: int = 10,
+    sortby: str = "timestamp",
+    page: int = 1,
 ) -> ChannelResourcesResponse:
+    """Per-channel resources with real totals and honored pagination.
+
+    ``count`` comes from the NNTP channel summary; ``page`` is taken
+    from the caller. Item-level pagination (returning the Nth page of
+    articles) is tracked as issue #3 follow-up work at the NNTP layer.
+    """
     plugin = site_plugin
-    total_num_articles = 124
-    plugin_by_slug = {slug: plugin for slug, _description, plugin in get_channels()}
+    total_num_articles = channel_summary(channel_slug).estimated_total_articles
+    plugin_by_slug = {slug: p for slug, _description, p in get_channels()}
     latest = [post_to_details(x) for x in get_last_n_posts(channel_slug, per_page)]
     for item in latest:
         item.thumbnail = plugin_by_slug[item.site].logo
 
     tenant_slug = next(iter(plugin.newsgroups.keys()))
+    num_pages = max(1, math.ceil(total_num_articles / per_page)) if per_page else 1
     return ChannelResourcesResponse(
         resources=CollectionDetails(
             items=latest,
@@ -295,11 +343,9 @@ def get_channel_resources(
             sortBy=sortby,
             sortByOptions=sort_options,
             pagination=PaginationOptions(
-                count=total_num_articles,  # TODO(anooparyal): get the
-                # total count of articles
-                # available
-                numPages=math.ceil(total_num_articles / per_page),
-                page=1,
+                count=total_num_articles,
+                numPages=num_pages,
+                page=page,
                 perPage=per_page,
                 perPageOptions=[3, 9, 30, 90],
             ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,4 +112,3 @@ def pytest_collection_modifyitems(
     for item in items:
         if "test_ome_node.py" in str(item.fspath):
             item.add_marker(skip_marker)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,115 @@
+"""Shared pytest configuration for the OME test suite.
+
+Problem this file solves
+------------------------
+``server/connection_pool.py`` registers a ``ClientFactory`` with
+``least_one=True`` at module import time. That causes ``pond`` to
+invoke ``ClientFactory.createInstance()`` eagerly, which opens a real
+NNTP socket. On a dev machine without a running INN server, any test
+that imports ``server.*`` fails during collection with
+``ConnectionRefusedError``.
+
+The fix is narrow and only affects tests:
+
+1. If port 119 on ``INN_SERVER_NAME`` (default ``localhost``) is
+   unreachable, we install a harmless stub in place of
+   ``nntp.NNTPClient`` so module import succeeds.
+2. If the port IS reachable (e.g. the CI workflow starts an ``inn``
+   service container), we do nothing and the real client is used.
+
+Individual tests that need deterministic behavior (e.g. raising inside
+``ClientContextManager``) still monkeypatch ``pond``/``NNTPClient``
+explicitly in the test body. This conftest only guarantees import
+succeeds.
+
+Default env vars are also set so ``server.connection_pool`` can read
+``INN_USERNAME`` / ``INN_PASSWORD`` without blowing up local runs.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# Provide non-secret test defaults for env-driven credentials.
+# Production deployments MUST set these explicitly (see .env.example).
+os.environ.setdefault("INN_USERNAME", "node")
+os.environ.setdefault("INN_PASSWORD", "node")  # noqa: S105
+os.environ.setdefault("INN_SERVER_NAME", "localhost")
+
+
+def _nntp_port_reachable(host: str, port: int = 119, timeout: float = 0.5) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _install_nntp_stub() -> None:
+    """Replace ``nntp.NNTPClient.__init__`` with a no-op for offline dev.
+
+    We monkeypatch ``__init__`` (not the class) so ``isinstance`` checks
+    against ``nntp.NNTPClient`` continue to work for any existing tests.
+    """
+    import nntp  # imported lazily so we never import it unless needed
+
+    def _stub_init(
+        self: Any,
+        host: str = "localhost",
+        port: int = 119,
+        **kwargs: Any,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self._init_kwargs = kwargs
+        self._stubbed = True
+
+    def _stub_date(self: Any) -> str:
+        return "20260101000000"
+
+    def _stub_quit(self: Any) -> None:
+        return None
+
+    def _stub_group(self: Any, _name: str) -> tuple[int, int, int, str]:
+        return (0, 0, 0, _name)
+
+    nntp.NNTPClient.__init__ = _stub_init  # type: ignore[method-assign]
+    nntp.NNTPClient.date = _stub_date  # type: ignore[method-assign]
+    nntp.NNTPClient.quit = _stub_quit  # type: ignore[method-assign]
+    nntp.NNTPClient.group = _stub_group  # type: ignore[method-assign]
+
+
+_host = os.environ["INN_SERVER_NAME"]
+_NNTP_STUBBED = not _nntp_port_reachable(_host)
+if _NNTP_STUBBED:
+    _install_nntp_stub()
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,  # noqa: ARG001
+    items: Iterable[pytest.Item],
+) -> None:
+    """Skip integration tests that need a live NNTP server when stubbed.
+
+    The existing ``tests/test_ome_node.py`` hits a real INN service. In CI
+    the INN service container is running and tests execute normally. On a
+    dev laptop without INN, we stub ``NNTPClient`` and those integration
+    tests cannot work — mark them skipped so the unit-test suite stays
+    green.
+    """
+    if not _NNTP_STUBBED:
+        return
+    skip_marker = pytest.mark.skip(
+        reason="Requires live NNTP server; port 119 unreachable.",
+    )
+    for item in items:
+        if "test_ome_node.py" in str(item.fspath):
+            item.add_marker(skip_marker)
+

--- a/tests/test_p0_config.py
+++ b/tests/test_p0_config.py
@@ -1,0 +1,100 @@
+"""Unit tests for ``server.config`` covering the CORS allow-list (P0 #1).
+
+The fix replaces ``allow_origins=[\"*\"]`` with an env-driven list. In
+production (``OME_ENV=prod``) the list must be set explicitly and must
+not contain a wildcard; in dev / test we allow sensible localhost
+defaults.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_allowed_origins_parses_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "OME_ALLOWED_ORIGINS",
+        "https://a.example, https://b.example ,https://c.example",
+    )
+    monkeypatch.setenv("OME_ENV", "prod")
+
+    from server.config import get_allowed_origins
+
+    assert get_allowed_origins() == [
+        "https://a.example",
+        "https://b.example",
+        "https://c.example",
+    ]
+
+
+def test_allowed_origins_drops_empty_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OME_ALLOWED_ORIGINS", "https://a.example,,  ,")
+    monkeypatch.setenv("OME_ENV", "prod")
+
+    from server.config import get_allowed_origins
+
+    assert get_allowed_origins() == ["https://a.example"]
+
+
+def test_allowed_origins_rejects_wildcard_in_prod(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OME_ALLOWED_ORIGINS", "*")
+    monkeypatch.setenv("OME_ENV", "prod")
+
+    from server.config import InvalidCORSConfigError, get_allowed_origins
+
+    with pytest.raises(InvalidCORSConfigError, match="wildcard"):
+        get_allowed_origins()
+
+
+def test_allowed_origins_dev_default_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OME_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("OME_ENV", "dev")
+
+    from server.config import get_allowed_origins
+
+    origins = get_allowed_origins()
+    assert any("localhost" in o for o in origins)
+    assert "*" not in origins
+
+
+def test_allowed_origins_prod_without_env_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OME_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("OME_ENV", "prod")
+
+    from server.config import InvalidCORSConfigError, get_allowed_origins
+
+    with pytest.raises(InvalidCORSConfigError, match="OME_ALLOWED_ORIGINS"):
+        get_allowed_origins()
+
+
+def test_allowed_origins_wildcard_allowed_in_dev(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicitly setting '*' in dev is permitted — some local setups
+    need it. The guard only fires in prod."""
+    monkeypatch.setenv("OME_ALLOWED_ORIGINS", "*")
+    monkeypatch.setenv("OME_ENV", "dev")
+
+    from server.config import get_allowed_origins
+
+    assert get_allowed_origins() == ["*"]
+
+
+def test_cors_middleware_kwargs_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The helper used by main.py returns safe defaults."""
+    monkeypatch.setenv("OME_ALLOWED_ORIGINS", "https://a.example")
+    monkeypatch.setenv("OME_ENV", "prod")
+
+    from server.config import get_cors_middleware_kwargs
+
+    kwargs = get_cors_middleware_kwargs()
+    assert kwargs["allow_origins"] == ["https://a.example"]
+    assert kwargs["allow_credentials"] is False
+    assert isinstance(kwargs["allow_methods"], list)
+    assert isinstance(kwargs["allow_headers"], list)

--- a/tests/test_p0_connection_pool.py
+++ b/tests/test_p0_connection_pool.py
@@ -1,0 +1,234 @@
+"""Unit tests for ``server.connection_pool`` covering P0 fixes.
+
+Covers issues:
+
+* **#2 Move hardcoded NNTP credentials out of source** — the factory
+  must read ``INN_USERNAME`` and ``INN_PASSWORD`` from the environment
+  and must refuse to construct a client when they are missing.
+* **#4 Connection pool ``__exit__`` swallows exceptions without
+  cleanup** — the context manager must *invalidate* (not recycle) a
+  connection when an ``NNTPError`` is raised inside the ``with`` block.
+
+These tests do not require a live NNTP server. They use the
+global ``NNTPClient`` stub installed by ``tests/conftest.py`` and
+monkeypatch ``pond`` for the context-manager tests.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any
+
+import nntp
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# -----------------------------------------------------------------------
+# Issue #2 — credentials come from environment, no hardcoded fallback
+# -----------------------------------------------------------------------
+
+
+@pytest.fixture
+def _reload_connection_pool() -> Iterator[Any]:
+    """Reload ``server.connection_pool`` so module-level state picks up
+    the current environment variables.
+
+    The module computes nothing at import time besides registering the
+    factory; the credentials are read inside ``createInstance()``, so a
+    reload is only needed if we want to prove the module itself imports
+    cleanly under the given env conditions. Kept for future-proofing.
+    """
+    import server.connection_pool as cp
+
+    yield importlib.reload(cp)
+
+
+def test_client_factory_reads_credentials_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+    _reload_connection_pool: Any,
+) -> None:
+    """``createInstance`` must pass env-driven credentials to NNTPClient."""
+    monkeypatch.setenv("INN_SERVER_NAME", "example.test")
+    monkeypatch.setenv("INN_USERNAME", "alice")
+    monkeypatch.setenv("INN_PASSWORD", "s3cret")
+
+    from server.connection_pool import ClientFactory
+
+    pooled = ClientFactory().createInstance()
+    client = pooled.keeped_object
+
+    assert client.host == "example.test"
+    assert client.port == 119
+    assert client._init_kwargs["username"] == "alice"
+    assert client._init_kwargs["password"] == "s3cret"
+
+
+def test_client_factory_raises_when_username_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    _reload_connection_pool: Any,
+) -> None:
+    """Missing ``INN_USERNAME`` is fatal — no silent fallback to 'node'."""
+    monkeypatch.delenv("INN_USERNAME", raising=False)
+    monkeypatch.setenv("INN_PASSWORD", "x")
+
+    from server.connection_pool import ClientFactory, MissingNNTPCredentialsError
+
+    with pytest.raises(MissingNNTPCredentialsError, match="INN_USERNAME"):
+        ClientFactory().createInstance()
+
+
+def test_client_factory_raises_when_password_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    _reload_connection_pool: Any,
+) -> None:
+    """Missing ``INN_PASSWORD`` is fatal — no silent fallback to 'node'."""
+    monkeypatch.setenv("INN_USERNAME", "x")
+    monkeypatch.delenv("INN_PASSWORD", raising=False)
+
+    from server.connection_pool import ClientFactory, MissingNNTPCredentialsError
+
+    with pytest.raises(MissingNNTPCredentialsError, match="INN_PASSWORD"):
+        ClientFactory().createInstance()
+
+
+def test_client_factory_empty_credentials_are_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    _reload_connection_pool: Any,
+) -> None:
+    """Empty-string credentials are treated as missing."""
+    monkeypatch.setenv("INN_USERNAME", "")
+    monkeypatch.setenv("INN_PASSWORD", "")
+
+    from server.connection_pool import ClientFactory, MissingNNTPCredentialsError
+
+    with pytest.raises(MissingNNTPCredentialsError):
+        ClientFactory().createInstance()
+
+
+# -----------------------------------------------------------------------
+# Issue #4 — __exit__ invalidates the connection on exception
+# -----------------------------------------------------------------------
+
+
+class _FakePooled:
+    """Minimal stand-in for ``pond.PooledObject`` used in context-manager
+    tests. Tracks whether it was returned to the pool or invalidated."""
+
+    def __init__(self) -> None:
+        self._client = nntp.NNTPClient()
+
+    def use(self) -> nntp.NNTPClient:
+        return self._client
+
+
+class _Recorder:
+    """Records the lifecycle of a pooled connection.
+
+    Replaces both the module-level ``pond`` (to capture ``borrow`` /
+    ``recycle``) and ``factory`` (to capture ``destroy``). A broken
+    connection must be *destroyed*, not recycled; that is the invariant
+    these tests encode.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.pooled = _FakePooled()
+
+    # pond surface
+    def borrow(self, _factory: Any) -> _FakePooled:
+        self.calls.append("borrow")
+        return self.pooled
+
+    def recycle(self, _pooled: Any, _factory: Any) -> None:
+        self.calls.append("recycle")
+
+    # factory surface
+    def destroy(self, _pooled: Any) -> None:
+        self.calls.append("destroy")
+
+    def createInstance(self) -> _FakePooled:  # noqa: N802 — match pond API
+        return self.pooled
+
+    def validate(self, _pooled: Any) -> bool:
+        return True
+
+    def reset(self, pooled: Any) -> Any:
+        return pooled
+
+
+@pytest.fixture
+def fake_pond(monkeypatch: pytest.MonkeyPatch) -> _Recorder:
+    import server.connection_pool as cp
+
+    rec = _Recorder()
+    monkeypatch.setattr(cp, "pond", rec)
+    monkeypatch.setattr(cp, "factory", rec)
+    return rec
+
+
+def test_context_manager_recycles_on_clean_exit(
+    fake_pond: _Recorder,
+) -> None:
+    """No exception → connection is returned to the pool (recycle)."""
+    from server.connection_pool import ClientContextManager
+
+    with ClientContextManager() as client:
+        assert isinstance(client, nntp.NNTPClient)
+
+    assert fake_pond.calls == ["borrow", "recycle"]
+    assert "destroy" not in fake_pond.calls
+
+
+def test_context_manager_destroys_on_nntp_error(
+    fake_pond: _Recorder,
+) -> None:
+    """NNTPError inside the block → connection is destroyed, not recycled."""
+    from server.connection_pool import ClientContextManager
+
+    with pytest.raises(nntp.NNTPError), ClientContextManager():
+        raise nntp.NNTPError("boom")
+
+    assert "destroy" in fake_pond.calls
+    assert "recycle" not in fake_pond.calls
+
+
+def test_context_manager_destroys_on_os_error(
+    fake_pond: _Recorder,
+) -> None:
+    """Socket / OS errors also indicate an unhealthy connection."""
+    from server.connection_pool import ClientContextManager
+
+    with pytest.raises(OSError, match="broken pipe"), ClientContextManager():
+        raise OSError("broken pipe")
+
+    assert "destroy" in fake_pond.calls
+    assert "recycle" not in fake_pond.calls
+
+
+def test_context_manager_destroys_on_unrelated_exception(
+    fake_pond: _Recorder,
+) -> None:
+    """Non-connection exceptions should also destroy — we can't prove the
+    connection is healthy after an unknown failure, so be conservative."""
+    from server.connection_pool import ClientContextManager
+
+    with pytest.raises(ValueError, match="domain"), ClientContextManager():
+        raise ValueError("domain")
+
+    assert "destroy" in fake_pond.calls
+    assert "recycle" not in fake_pond.calls
+
+
+def test_context_manager_does_not_suppress_exception(
+    fake_pond: _Recorder,  # noqa: ARG001
+) -> None:
+    """``__exit__`` must return falsy so exceptions propagate."""
+    from server.connection_pool import ClientContextManager
+
+    cm = ClientContextManager()
+    cm.__enter__()
+    suppressed = cm.__exit__(ValueError, ValueError("x"), None)
+    assert suppressed is False or suppressed is None

--- a/tests/test_p0_main_endpoints.py
+++ b/tests/test_p0_main_endpoints.py
@@ -1,0 +1,137 @@
+"""End-to-end-ish FastAPI route tests for the P0 fixes.
+
+Asserts:
+
+* ``/api/imls/v2/collections/browse/`` accepts and returns the ``page``
+  query parameter (issue #3).
+* ``/api/imls/v2/collections/{channel}/{_id}/resources`` accepts and
+  returns ``page`` (issue #3).
+* The CORS middleware honors :func:`server.config.get_allowed_origins`
+  (issue #1).
+
+Runs against FastAPI's in-process ``TestClient``. Business logic is
+still mocked by patching ``server.utils`` collaborators; we're testing
+the endpoint wiring here, not NNTP.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from server.schemas import ChannelSummary, Post
+
+if TYPE_CHECKING:
+    pass
+
+
+def _post(post_id: int = 1, channel: str = "ome.alpha") -> Post:
+    return Post(
+        id=post_id,
+        channels=[channel],
+        admin_contact="librarian@example.test",
+        subject=f"Subject {post_id}",
+        body="body",
+        attachments=[],
+        date=datetime(2026, 4, 19, tzinfo=UTC),
+    )
+
+
+class _FakePlugin:
+    def __init__(self, slug: str) -> None:
+        self.newsgroups = {slug: "desc"}
+        self.site_name = "Site"
+        self.librarian_contact = "librarian@example.test"
+        self.logo = "/static/logo.svg"
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    """FastAPI TestClient with ``server.utils`` collaborators mocked.
+
+    CORS env is set so ``get_cors_middleware_kwargs`` returns a valid
+    config at app import time.
+    """
+    monkeypatch.setenv("OME_ENV", "dev")
+    monkeypatch.setenv("OME_ALLOWED_ORIGINS", "https://ui.example.test")
+
+    import server.utils as utils
+
+    channels = [("ome.alpha", "Alpha", _FakePlugin("ome.alpha"))]
+    summaries = {
+        "ome.alpha": ChannelSummary(
+            name="ome.alpha",
+            estimated_total_articles=50,
+            first_article=1,
+            last_article=50,
+        ),
+    }
+    posts = [_post(i) for i in range(1, 6)]
+
+    def _fake_get_channels() -> Any:
+        yield from channels
+
+    monkeypatch.setattr(utils, "get_channels", _fake_get_channels)
+    monkeypatch.setattr(utils, "channel_summary", lambda s, *a, **k: summaries[s])
+    monkeypatch.setattr(
+        utils, "get_last_n_posts", lambda _slug, num: posts[:num]
+    )
+    monkeypatch.setattr(utils, "site_plugin", _FakePlugin("ome.alpha"))
+
+    from server.main import app
+
+    return TestClient(app)
+
+
+def test_browse_endpoint_accepts_page_query(client: TestClient) -> None:
+    resp = client.get("/api/imls/v2/collections/browse/?page=4&per_page=10")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["collections"]["pagination"]["page"] == 4
+    assert body["collections"]["pagination"]["count"] == 50  # real, not 124
+    assert body["collections"]["pagination"]["perPage"] == 10
+
+
+def test_browse_endpoint_defaults(client: TestClient) -> None:
+    resp = client.get("/api/imls/v2/collections/browse/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["collections"]["pagination"]["page"] == 1
+
+
+def test_channel_resources_endpoint_accepts_page(client: TestClient) -> None:
+    resp = client.get(
+        "/api/imls/v2/collections/ome.alpha/0/resources?page=2&per_page=10"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["resources"]["pagination"]["page"] == 2
+    assert body["resources"]["pagination"]["count"] == 50
+
+
+def test_cors_uses_configured_origin(client: TestClient) -> None:
+    resp = client.options(
+        "/api/imls/v2/collections/browse/",
+        headers={
+            "origin": "https://ui.example.test",
+            "access-control-request-method": "GET",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "https://ui.example.test"
+
+
+def test_cors_rejects_unknown_origin(client: TestClient) -> None:
+    resp = client.options(
+        "/api/imls/v2/collections/browse/",
+        headers={
+            "origin": "https://evil.example.test",
+            "access-control-request-method": "GET",
+        },
+    )
+    # Starlette returns 400 when the origin isn't on the allow-list.
+    # The important thing: no access-control-allow-origin echoed back.
+    assert resp.headers.get("access-control-allow-origin") != "https://evil.example.test"

--- a/tests/test_p0_main_endpoints.py
+++ b/tests/test_p0_main_endpoints.py
@@ -76,9 +76,7 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
     monkeypatch.setattr(utils, "get_channels", _fake_get_channels)
     monkeypatch.setattr(utils, "channel_summary", lambda s, *a, **k: summaries[s])
-    monkeypatch.setattr(
-        utils, "get_last_n_posts", lambda _slug, num: posts[:num]
-    )
+    monkeypatch.setattr(utils, "get_last_n_posts", lambda _slug, num: posts[:num])
     monkeypatch.setattr(utils, "site_plugin", _FakePlugin("ome.alpha"))
 
     from server.main import app
@@ -134,4 +132,6 @@ def test_cors_rejects_unknown_origin(client: TestClient) -> None:
     )
     # Starlette returns 400 when the origin isn't on the allow-list.
     # The important thing: no access-control-allow-origin echoed back.
-    assert resp.headers.get("access-control-allow-origin") != "https://evil.example.test"
+    assert (
+        resp.headers.get("access-control-allow-origin") != "https://evil.example.test"
+    )

--- a/tests/test_p0_utils.py
+++ b/tests/test_p0_utils.py
@@ -1,0 +1,213 @@
+"""Unit tests for ``server.utils`` covering P0 issue #3.
+
+Goals:
+
+* ``post_to_details`` returns honest default values (no fabricated
+  ``source=\"Course Related Material\"``, ``visits=22`` etc.).
+* ``browse_results`` and ``get_channel_resources`` report a real total
+  article count (aggregated via ``ome_node.channel_summary``), not the
+  hardcoded ``124``.
+* Both endpoints honor a ``page`` parameter — the returned
+  ``pagination.page`` reflects the request.
+* ``get_channel_summary`` uses the real article count and empty
+  education-levels list (the previous hardcoded values were fabricated).
+
+All tests are pure: they monkeypatch ``ome_node`` and the plugin
+registry so no NNTP socket is ever touched.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from server.schemas import ChannelSummary, Post
+
+if TYPE_CHECKING:
+    pass
+
+
+def _post(
+    post_id: int = 1,
+    channel: str = "ome.test",
+    subject: str = "Hello",
+    body: str = "World",
+) -> Post:
+    return Post(
+        id=post_id,
+        channels=[channel],
+        admin_contact="librarian@example.test",
+        subject=subject,
+        body=body,
+        attachments=[],
+        date=datetime(2026, 4, 19, tzinfo=UTC),
+    )
+
+
+class _FakePlugin:
+    def __init__(
+        self,
+        slug: str = "ome.test",
+        description: str = "Test channel",
+        site_name: str = "Test Site",
+    ) -> None:
+        self.newsgroups = {slug: description}
+        self.site_name = site_name
+        self.librarian_contact = "librarian@example.test"
+        self.logo = f"/static/{slug}.svg"
+
+
+@pytest.fixture
+def patched_utils(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Patch utils' collaborators with deterministic fakes.
+
+    Returns a dict of hooks the tests mutate to shape behavior per-test.
+    """
+    import server.utils as utils
+
+    state: dict[str, Any] = {
+        "channels": [
+            ("ome.alpha", "Alpha channel", _FakePlugin("ome.alpha", "Alpha channel")),
+            ("ome.beta", "Beta channel", _FakePlugin("ome.beta", "Beta channel")),
+        ],
+        "summaries": {
+            "ome.alpha": ChannelSummary(
+                name="ome.alpha",
+                estimated_total_articles=40,
+                first_article=1,
+                last_article=40,
+            ),
+            "ome.beta": ChannelSummary(
+                name="ome.beta",
+                estimated_total_articles=60,
+                first_article=1,
+                last_article=60,
+            ),
+        },
+        "latest_by_channel": {
+            "ome.alpha": [_post(i, "ome.alpha", f"A{i}") for i in range(1, 6)],
+            "ome.beta": [_post(100 + i, "ome.beta", f"B{i}") for i in range(1, 6)],
+        },
+    }
+
+    def _fake_get_channels() -> Any:
+        yield from state["channels"]
+
+    def _fake_channel_summary(slug: str, *_: Any, **__: Any) -> ChannelSummary:
+        return state["summaries"][slug]
+
+    def _fake_get_last_n_posts(slug: str, num: int) -> list[Post]:
+        return state["latest_by_channel"].get(slug, [])[:num]
+
+    monkeypatch.setattr(utils, "get_channels", _fake_get_channels)
+    monkeypatch.setattr(utils, "channel_summary", _fake_channel_summary)
+    monkeypatch.setattr(utils, "get_last_n_posts", _fake_get_last_n_posts)
+    # site_plugin is used for top-level metadata (tenant slug, contact)
+    monkeypatch.setattr(utils, "site_plugin", _FakePlugin("ome.alpha", "Alpha channel"))
+
+    return state
+
+
+# -----------------------------------------------------------------------
+# post_to_details — honest defaults
+# -----------------------------------------------------------------------
+
+
+def test_post_to_details_has_no_fabricated_values() -> None:
+    from server.utils import post_to_details
+
+    details = post_to_details(_post(42, "ome.alpha", "Some Subject", "Body text"))
+
+    # Previous bug: these were hardcoded fake values shipped to clients.
+    assert details.source == ""  # was "Course Related Material"
+    assert details.grade_sublevel == []  # was ["High School"]
+    assert details.license == ""  # was "educational-use-permitted"
+    assert details.license_cou_bucket == ""
+    assert details.license_types == []
+    assert details.license_bucket_title == ""
+    assert details.visits == 0  # was 22
+
+    # Real values that should still round-trip unchanged:
+    assert details.id == 42
+    assert details.title == "Some Subject"
+    assert details.abstract == "Body text"
+    assert details.site == "ome.alpha"
+    assert details.collections == ["ome.alpha"]
+
+
+# -----------------------------------------------------------------------
+# browse_results — real count, real page
+# -----------------------------------------------------------------------
+
+
+def test_browse_results_total_count_aggregates_channel_summaries(
+    patched_utils: dict[str, Any],  # noqa: ARG001 — fixture wires patches
+) -> None:
+    from server.utils import browse_results
+
+    result = browse_results(per_page=10)
+    # 40 + 60 = 100 across the two channels, not the hardcoded 124.
+    assert result.collections.pagination.count == 100
+    assert result.collections.pagination.numPages == 10
+
+
+def test_browse_results_honors_page_parameter(
+    patched_utils: dict[str, Any],  # noqa: ARG001
+) -> None:
+    from server.utils import browse_results
+
+    result = browse_results(per_page=10, page=3)
+    assert result.collections.pagination.page == 3
+    assert result.collections.pagination.perPage == 10
+
+
+def test_browse_results_defaults_to_page_1(
+    patched_utils: dict[str, Any],  # noqa: ARG001
+) -> None:
+    from server.utils import browse_results
+
+    result = browse_results(per_page=10)
+    assert result.collections.pagination.page == 1
+
+
+# -----------------------------------------------------------------------
+# get_channel_resources — real count, real page
+# -----------------------------------------------------------------------
+
+
+def test_get_channel_resources_uses_real_count(
+    patched_utils: dict[str, Any],  # noqa: ARG001
+) -> None:
+    from server.utils import get_channel_resources
+
+    result = get_channel_resources("ome.alpha", per_page=10)
+    assert result.resources.pagination.count == 40  # alpha's estimate
+    assert result.resources.pagination.numPages == 4
+
+
+def test_get_channel_resources_honors_page(
+    patched_utils: dict[str, Any],  # noqa: ARG001
+) -> None:
+    from server.utils import get_channel_resources
+
+    result = get_channel_resources("ome.beta", per_page=30, page=2)
+    assert result.resources.pagination.page == 2
+    assert result.resources.pagination.count == 60
+
+
+# -----------------------------------------------------------------------
+# get_channel_summary — real count, no fabricated education levels
+# -----------------------------------------------------------------------
+
+
+def test_get_channel_summary_uses_real_count_and_empty_levels(
+    patched_utils: dict[str, Any],  # noqa: ARG001
+) -> None:
+    from server.utils import get_channel_summary
+
+    result = get_channel_summary("ome.beta")
+    # Before: hardcoded numResources=100 and fabricated educationLevels list.
+    assert result.collection.numResources == 60
+    assert result.collection.educationLevels == []


### PR DESCRIPTION
## Summary
Four P0 security & reliability fixes, developed TDD (failing test → minimal
implementation → refactor). 28 new unit tests + offline-safe test
infrastructure.

Tracking issues (on fork, since upstream has issues disabled):
- [jsgoecke/Open-Metadata-Exchange#1](https://github.com/jsgoecke/Open-Metadata-Exchange/issues/1) — CORS allow-list
- [jsgoecke/Open-Metadata-Exchange#2](https://github.com/jsgoecke/Open-Metadata-Exchange/issues/2) — NNTP credentials from env
- [jsgoecke/Open-Metadata-Exchange#3](https://github.com/jsgoecke/Open-Metadata-Exchange/issues/3) — remove hardcoded mock data
- [jsgoecke/Open-Metadata-Exchange#4](https://github.com/jsgoecke/Open-Metadata-Exchange/issues/4) — connection pool `__exit__` cleanup

## Behavior changes
| Area | Before | After |
|---|---|---|
| CORS | `allow_origins=["*"]` hardcoded | Env-driven `OME_ALLOWED_ORIGINS`; wildcards forbidden when `OME_ENV=prod` |
| NNTP creds | Hardcoded `"node"/"node"` | Required env vars `INN_USERNAME`/`INN_PASSWORD`; missing → `MissingNNTPCredentialsError` |
| Pool `__exit__` | Silently recycled broken connections | Destroys on any exception; only clean exits are recycled |
| Pagination | Hardcoded `total_num_articles=124`, `page=1` | Real count via `channel_summary().estimated_total_articles`; `page` query param honored |
| Detail fields | Fake `source`/`grade_sublevel`/`license`/`visits` | Honest empty/zero defaults; TODO for real metadata plumbing |

## Deployer migration (breaking)
- Set `INN_USERNAME` and `INN_PASSWORD` on every environment; the server now refuses to start without them (fail-fast, by design).
- Set `OME_ENV=prod` + `OME_ALLOWED_ORIGINS=<csv>` on production; otherwise `InvalidCORSConfigError` at startup.
- New `.env.example` documents the full set. `docker-compose*.yml` files inject sensible dev defaults matching the preseeded INN users.
- Full details in `docs/changes/p0-security-reliability.md`.

## Test plan
- [x] `uv run pytest` offline (55 passed, 56 skipped via auto-stub in `tests/conftest.py`)
- [ ] CI integration run against the `inn-service` container
- [ ] Manual smoke: `OME_ENV=prod` without `OME_ALLOWED_ORIGINS` → `InvalidCORSConfigError` (by design)
- [ ] Manual smoke: unset `INN_USERNAME`/`INN_PASSWORD` → `MissingNNTPCredentialsError` (by design)

## Follow-ups (intentionally out of scope)
- NNTP-level offset pagination (`ome_node.get_last_n_posts` has no offset; the page *metadata* is now correct, which fixes the primary bug).
- Real metadata sources for `source`/`grade_sublevel`/`license`/`visits` (requires extending the plugin metadata schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)