### PR TITLE
docs: add .env.example (#15, split from #287)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,54 @@
+# ---------------------------------------------------------------------------
+# Open Metadata Exchange — example environment configuration
+# ---------------------------------------------------------------------------
+# Copy this file to `.env` for local development. Docker Compose reads
+# `.env` automatically. DO NOT commit your real `.env`.
+#
+# Every variable below is read by `server/` modules at runtime. Where
+# a sensible dev default exists, it is documented inline.
+
+# --- NNTP / INN server -----------------------------------------------------
+# Hostname of the INN server the FastAPI container talks to. Inside
+# docker-compose this is the service name (`nntp-server`); on the host
+# it is typically `localhost`.
+INN_SERVER_NAME=localhost
+
+# Port is optional; defaults to 119 if unset.
+# INN_PORT=119
+
+# INN credentials. REQUIRED — there is no hardcoded fallback. See
+# `server/connection_pool.py`. In docker-compose these default to the
+# values preseeded by `server_config/news_server`.
+INN_USERNAME=node
+INN_PASSWORD=node
+
+# --- CORS / deployment environment ----------------------------------------
+# Any value other than `prod` activates dev behavior: wildcard origins
+# are tolerated, and `OME_ALLOWED_ORIGINS` may be omitted (localhost
+# defaults are used). In prod both guards are strict.
+OME_ENV=dev
+
+# Comma-separated list of origins allowed by the FastAPI CORS
+# middleware. Required in prod. Wildcards (`*`) are forbidden in prod.
+# OME_ALLOWED_ORIGINS=https://ome.example.org,https://admin.example.org
+
+# --- FastAPI server --------------------------------------------------------
+# Port the FastAPI app listens on.
+SERVER_PORT=5001
+
+# --- Plugin selection ------------------------------------------------------
+# Dotted path to the OME plugin class this node hosts. See
+# `server/get_ome_plugins.py`.
+CMS_PLUGIN=server.plugins.qubes.plugin.QubesPlugin
+
+# --- Rate limiting (issue #5) ---------------------------------------------
+# slowapi per-IP default, applied to every FastAPI route. Format:
+# "<count>/<unit>" where unit is second|minute|hour|day. Unset ->
+# generous default ("1000/minute"). Example tightening for prod:
+# OME_RATE_LIMIT=60/minute
+
+# --- Logging (issue #9) ---------------------------------------------------
+# Minimum log level for the `server` logger. Default: INFO. In prod the
+# formatter switches to JSON; in dev it is human-readable. See
+# `server/logging_config.py`.
+# OME_LOG_LEVEL=DEBUG

--- a/tests/test_env_example.py
+++ b/tests/test_env_example.py
@@ -47,6 +47,5 @@ def test_env_example_documents_key(key: str) -> None:
 def test_env_example_header_warns_against_committing_real_secrets() -> None:
     text = (REPO_ROOT / ".env.example").read_text()
     assert "DO NOT commit" in text, (
-        ".env.example header should warn contributors not to commit a "
-        "real .env file"
+        ".env.example header should warn contributors not to commit a real .env file"
     )

--- a/tests/test_env_example.py
+++ b/tests/test_env_example.py
@@ -12,8 +12,6 @@ example (e.g. a value where a comment is expected) still surfaces a
 clear failure.
 """
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/tests/test_env_example.py
+++ b/tests/test_env_example.py
@@ -1,0 +1,52 @@
+"""`.env.example` regression guards.
+
+Split off from the P3 docs PR so `.env.example` can land as a
+minimal, independently-reviewable change — a short, low-risk first
+PR from a new contributor is the easiest for a maintainer to approve
+for CI, which then unblocks workflow runs on the larger follow-up
+PRs from the same author.
+
+Every key below is read by a `server/` module at runtime. The tests
+grep the example file rather than importing it so a malformed
+example (e.g. a value where a comment is expected) still surfaces a
+clear failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_ENV_EXAMPLE_REQUIRED_KEYS = (
+    "INN_SERVER_NAME",
+    "INN_USERNAME",
+    "INN_PASSWORD",
+    "OME_ENV",
+    "OME_ALLOWED_ORIGINS",
+    "CMS_PLUGIN",
+    "OME_RATE_LIMIT",
+    "OME_LOG_LEVEL",
+)
+
+
+def test_env_example_exists() -> None:
+    path = REPO_ROOT / ".env.example"
+    assert path.exists(), ".env.example is required (issue #15)"
+
+
+@pytest.mark.parametrize("key", _ENV_EXAMPLE_REQUIRED_KEYS)
+def test_env_example_documents_key(key: str) -> None:
+    path = REPO_ROOT / ".env.example"
+    text = path.read_text()
+    assert key in text, f".env.example must mention {key!r} (issue #15)"
+
+
+def test_env_example_header_warns_against_committing_real_secrets() -> None:
+    text = (REPO_ROOT / ".env.example").read_text()
+    assert "DO NOT commit" in text, (
+        ".env.example header should warn contributors not to commit a "
+        "real .env file"
+    )


### PR DESCRIPTION
Partial progress toward #15, split off from #287 per reviewer request.

## Summary
Smallest possible self-contained change so maintainer CI approval can land first on a minimal PR. Approval unblocks workflow runs on the larger follow-up PRs from the same author.

## Changes
- `.env.example` — every env var read by `server/` (INN_*, OME_ENV, OME_ALLOWED_ORIGINS, SERVER_PORT, CMS_PLUGIN, OME_RATE_LIMIT, OME_LOG_LEVEL), with inline comments and a header warning against committing real secrets.
- `tests/test_env_example.py` — 10 parametrized guards pinning the required keys.

## Follow-up
The per-plugin READMEs, `CONTRIBUTING.md` expansion, and top-level Swagger links that were part of the original #287 remain in #287 (which will be rebased to drop `.env.example` once this PR lands).

## Test plan
- [x] `INN_USERNAME=node INN_PASSWORD=node OME_ENV=dev uv run pytest tests/test_env_example.py` — 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)