### PR TITLE
chore(pre-commit): add astral `ty` type checker hook (ISKME#237)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,3 +81,35 @@ repos:
     rev: 0.11.6
     hooks:
       - id: uv-lock
+
+  # Astral's `ty` — Python type checker (pre-release). Tracking ISKME#237.
+  # No upstream pre-commit repo yet (astral-sh/ty#269), so we declare a
+  # local hook and install ty into pre-commit's managed venv.
+  # The --ignore list reflects ty 0.0.31's ruleset; entries should be
+  # ratcheted off as the underlying issues get fixed.
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty (astral) — Python type checker
+        language: python
+        additional_dependencies:
+          - ty==0.0.31
+        entry: ty check
+        args:
+          - --ignore=invalid-argument-type
+          - --ignore=invalid-assignment
+          - --ignore=invalid-method-override
+          - --ignore=invalid-parameter-default
+          - --ignore=invalid-return-type
+          - --ignore=no-matching-overload
+          - --ignore=not-subscriptable
+          - --ignore=possibly-missing-attribute
+          - --ignore=unknown-argument
+          - --ignore=unresolved-attribute
+          - --ignore=unresolved-global
+          - --ignore=unresolved-import
+          - --ignore=unresolved-reference
+          - --ignore=unsupported-operator
+          - --output-format=concise
+        pass_filenames: false
+        types: [python]

--- a/tests/test_ty_precommit_hook.py
+++ b/tests/test_ty_precommit_hook.py
@@ -1,0 +1,86 @@
+"""Regression guards for the `ty` pre-commit hook — ISKME#237.
+
+These tests pin the shape of the `ty` entry in `.pre-commit-config.yaml`
+so that accidental removal of a rule or the hook itself fails CI.
+
+The ignore list reflects the current ty pre-release ruleset: it extends
+the set from the upstream issue to account for rule renames
+(`non-subscriptable` → `not-subscriptable`) and errors surfaced by newer
+ty versions that are out of scope for this initial integration. Ratchet
+these off in follow-up PRs as the codebase cleans up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+CONFIG_PATH = Path(__file__).parent.parent / ".pre-commit-config.yaml"
+
+REQUIRED_IGNORES = frozenset(
+    {
+        "invalid-argument-type",
+        "invalid-assignment",
+        "invalid-method-override",
+        "invalid-parameter-default",
+        "invalid-return-type",
+        "no-matching-overload",
+        "not-subscriptable",
+        "possibly-missing-attribute",
+        "unknown-argument",
+        "unresolved-attribute",
+        "unresolved-global",
+        "unresolved-import",
+        "unresolved-reference",
+        "unsupported-operator",
+    },
+)
+
+
+@pytest.fixture(scope="module")
+def ty_hook() -> dict:
+    cfg = yaml.safe_load(CONFIG_PATH.read_text())
+    for repo in cfg["repos"]:
+        for hook in repo.get("hooks", []):
+            if hook.get("id") == "ty":
+                return hook
+    pytest.fail("No `ty` hook found in .pre-commit-config.yaml")
+
+
+def test_ty_hook_is_declared(ty_hook: dict) -> None:
+    assert ty_hook["id"] == "ty"
+
+
+def test_ty_hook_has_pinned_dependency(ty_hook: dict) -> None:
+    deps = ty_hook.get("additional_dependencies", [])
+    assert any(d.startswith("ty==") for d in deps), (
+        f"ty must be pinned to an exact version in additional_dependencies; got {deps}"
+    )
+
+
+def test_ty_hook_invokes_ty_check(ty_hook: dict) -> None:
+    assert ty_hook["entry"] == "ty check"
+
+
+def test_ty_hook_uses_concise_output(ty_hook: dict) -> None:
+    assert "--output-format=concise" in ty_hook["args"]
+
+
+def test_ty_hook_does_not_pass_filenames(ty_hook: dict) -> None:
+    # ty walks the project itself; passing filenames would scope it per-file
+    # and miss cross-file inference.
+    assert ty_hook.get("pass_filenames") is False
+
+
+def test_ty_hook_runs_on_python_files_only(ty_hook: dict) -> None:
+    assert ty_hook.get("types") == ["python"]
+
+
+@pytest.mark.parametrize("rule", sorted(REQUIRED_IGNORES))
+def test_ty_hook_ignores_known_noisy_rule(ty_hook: dict, rule: str) -> None:
+    assert f"--ignore={rule}" in ty_hook["args"], (
+        f"Expected --ignore={rule} in ty hook args so the current codebase passes; "
+        "remove once the underlying issues are fixed."
+    )


### PR DESCRIPTION
## Summary
Closes #237.

Adds a local pre-commit hook that runs Astral's `ty` Python type checker. Since `astral-sh/ty` does not yet publish an official pre-commit repo ([astral-sh/ty#269](https://github.com/astral-sh/ty/issues/269)), the hook uses `language: python` with `ty==0.0.31` as an `additional_dependency` — pre-commit installs it into a managed venv, so no global `ty` install is required.

The `--ignore` list extends the set proposed in the issue to account for rule renames (`non-subscriptable` → `not-subscriptable`) and a handful of diagnostics surfaced by newer `ty` pre-release versions. Treat these as a starting budget — ratchet them off in follow-up PRs as the underlying issues get fixed.

### Hook

```yaml
- repo: local
  hooks:
    - id: ty
      name: ty (astral) — Python type checker
      language: python
      additional_dependencies:
        - ty==0.0.31
      entry: ty check
      args: [--ignore=..., --output-format=concise]
      pass_filenames: false
      types: [python]
```

## Test plan
- [x] `uvx pre-commit run ty --all-files` — **passes** on current main
- [x] `uv run pytest tests/test_ty_precommit_hook.py` — **20 tests pass** (hook shape, pinned version, each required ignore rule)
- [x] Non-NNTP test suites green (NNTP-dependent tests require a live INN container locally)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)