### PR TITLE
ci: add fastapi + pyyaml to uvx test-dependency list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           enable-cache: true
       - run: uv python install  # Version from pyproject.toml project.requires-python
       # TODO(@cclauss): Remove `|| true` when tests are fixed
-      - run: uvx --with=beautifulsoup4,dateparser,httpx,pondpond,pydantic,pynntp,pytest-run-parallel pytest --iterations=8 --parallel-threads=auto --ignore-gil-enabled
+      - run: uvx --with=beautifulsoup4,dateparser,fastapi,httpx,pondpond,pydantic,pynntp,pytest-run-parallel,pyyaml pytest --iterations=8 --parallel-threads=auto --ignore-gil-enabled
       - run: uv run scripts/nntp_io.py
 
   front-end:


### PR DESCRIPTION
## Summary

The `inn-docker_uv` job in `.github/workflows/ci.yml` runs tests via

\`\`\`
uvx --with=beautifulsoup4,dateparser,httpx,pondpond,pydantic,pynntp,pytest-run-parallel pytest …
\`\`\`

Two recent additions broke CI on every open PR except one:

- \`tests/test_p0_main_endpoints.py\` (and friends on PRs #285–#288) imports \`from fastapi.testclient import TestClient\`, but \`fastapi\` was not in the \`--with=\` list.
- \`tests/test_ty_precommit_hook.py\` (added by PR #293, the ty hook) imports \`yaml\`, but \`pyyaml\` was not in the \`--with=\` list.

Result across open PRs: \`ModuleNotFoundError\` at collection time, exit code 2, job fails.

This PR adds \`fastapi\` and \`pyyaml\` to the \`--with=\` list so the CI's ephemeral test environment matches what the tests actually import.

## Why minimal / why not switch to \`uv run pytest\`

A larger refactor would move these test-time deps into \`[dependency-groups].dev\` and switch CI to \`uv sync --group dev && uv run pytest\`. That's cleaner but touches more files and conflates "fix CI today" with "rethink CI dependency layout." This PR is surgical so it can land fast and unblock the other open PRs immediately.

## Test plan

- [x] \`uvx pre-commit run --all-files\` passes locally.
- [x] \`uv run pytest --ignore=tests/test_ome_node.py\` passes locally (37/37; \`test_ome_node.py\` skipped because it needs a live INN server, which is a pre-existing unrelated condition).
- [ ] CI \`inn-docker_uv\` job goes green on this PR.
- [ ] After merge, rebasing the other open PRs will also clear the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)