### PR TITLE
ci: publish prebuilt Docker images to GHCR (#208)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,76 @@
+name: docker-publish
+
+# Builds and publishes OME Docker images to the GitHub Container Registry
+# (ghcr.io) so integrators can pull prebuilt images instead of cloning and
+# building locally. See issue #208.
+#
+# Published images appear under the repository's "Packages" tab on GitHub
+# (i.e. they are published as releases on GitHub).
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*.*.*' ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: server
+            dockerfile: Dockerfile
+            context: .
+          - name: frontend
+            dockerfile: Dockerfile-fe
+            context: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Lowercase repository name
+        id: repo
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.repo.outputs.name }}/${{ matrix.name }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=main-,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ docker compose build
 docker compose up
 open http://localhost:5001
 ```
+
+## Prebuilt Docker images
+
+Prebuilt OME images are published as releases on GitHub (GitHub
+Container Registry, under this repository's **Packages** tab):
+
+```bash
+# Backend (FastAPI server)
+docker pull ghcr.io/iskme/open-metadata-exchange/server:latest
+
+# Frontend (nginx + React)
+docker pull ghcr.io/iskme/open-metadata-exchange/frontend:latest
+```
+
+Each push to `main` publishes `:latest` and `:main-<shortsha>`. Git tags
+matching `v*.*.*` publish semver tags (`:1.2.3`, `:1.2`, `:1`). See
+[`.github/workflows/docker-publish.yml`](./.github/workflows/docker-publish.yml).
 * [InterNetNews](https://github.com/InterNetNews/inn) (INN) backend that houses the metadata.
     * <https://www.isc.org/othersoftware/#INN>
     * <https://www.eyrie.org/~eagle/software/inn/docs-2.7>


### PR DESCRIPTION
## Summary

Closes #208.

Adds `.github/workflows/docker-publish.yml` so the OME backend and frontend are built and **published as releases on GitHub** — specifically to the GitHub Container Registry (`ghcr.io`), where they appear under this repository's **Packages** tab. Downstream integrators (e.g. the World Historical Gazetteer's K8s deployment described in the issue) can then pull prebuilt images instead of cloning the repo and building locally.

## What the workflow does

- Triggers on `push` to `main`, on pushing a git tag matching `v*.*.*`, and via `workflow_dispatch`.
- Uses a matrix to build two images in parallel:
  - `ghcr.io/iskme/open-metadata-exchange/server` (from `Dockerfile`)
  - `ghcr.io/iskme/open-metadata-exchange/frontend` (from `Dockerfile-fe`)
- Tagging via `docker/metadata-action@v5`:
  - On push to `main`: `:latest` and `:main-<shortsha>`
  - On `v*.*.*` tag push: `:1.2.3`, `:1.2`, `:1`
- Authenticates to GHCR with the built-in `GITHUB_TOKEN` (no extra secrets needed).
- Uses BuildKit with GitHub Actions cache (`type=gha`) scoped per-image.
- Runs with least-privilege permissions: `contents: read`, `packages: write`.

The existing `ci.yml` is unchanged — testing and publishing stay in separate workflows.

## Docs

`README.md` gains a short "Prebuilt Docker images" section with the `docker pull` commands and a pointer to the workflow.

## Test plan

- [ ] Merge to `main` → confirm workflow runs and `:latest` + `:main-<sha>` appear under Packages for both images.
- [ ] Push a `v0.0.1` tag (or similar test tag) → confirm semver tags `:0.0.1`, `:0.0`, `:0` are published.
- [ ] `docker pull ghcr.io/iskme/open-metadata-exchange/server:latest` succeeds from an unauthenticated client once the package is marked public (Package settings → "Change visibility").
- [ ] `docker pull ghcr.io/iskme/open-metadata-exchange/frontend:latest` likewise.

## Pre-existing test failure (not a regression)

`uv run pytest` fails to collect `tests/test_ome_node.py` locally because that module opens an NNTP connection at import time and no live NNTP server is running — this matches the scenario `CLAUDE.md` explicitly identifies as a known pre-existing failure. All other tests pass:

```
collected 27 items
tests/test_nntp_article.py ....                                   [ 14%]
tests/test_openstax_plugin.py .....                               [ 33%]
tests/test_schemas.py ........                                    [ 62%]
tests/test_whg_plugin.py ..........                               [100%]
============================== 27 passed in 0.16s ==============================
```

This change is workflow/YAML + README only and touches no Python code, so it cannot have introduced the NNTP failure.

## Notes / follow-ups

- **Package visibility:** GHCR packages default to private. After the first successful publish, a maintainer with admin rights will need to flip each package to **Public** (repo → Packages → package → Package settings → Change visibility).
- **Multi-arch:** Builds are `linux/amd64` only. Adding `linux/arm64` is a small follow-up (QEMU + `platforms:` on `build-push-action`) and is recommended for K8s consumers, but kept out of this PR to keep scope tight.