### PR TITLE
Dependabot: cooldown: default-days: 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
   - package-ecosystem: "uv"
     directory: /
     groups:
@@ -19,3 +21,5 @@ updates:
           - "*"  # Group all uv updates into a single larger pull request
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
% `uvx zizmor --fix ` # https://zizmor.sh
```diff
+    cooldown:
+      default-days: 7
```
https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html