### PR TITLE
Upgrade from httpx to httpx2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,7 +85,7 @@ pre-commit install
   import and let Python >= 3.13 handle the annotations natively.
 - Avoid where possible variables that can be polymorphic with `None` as in `s: str | None`.
 - Use assignment expresstions (:=) where it makes sense.
-- Prefer the use of `httpx.AsyncClient()` instead of `httpx.Client()`.
+- Prefer the use of `httpx2.AsyncClient()` instead of `httpx2.Client()`.
 - The variable name `client` is unclear so instead use `httpx_async_client`, `nntp_client`, etc.
 
 ## Plugin Architecture

--- a/.github/skills/plugin.md
+++ b/.github/skills/plugin.md
@@ -90,12 +90,12 @@ wired into Sphinx correctly.
 
 Before writing any code, check whether the source site exposes a public API:
 
-- **JSON/REST API available** → fetch data with `httpx` and generate Pydantic models from
+- **JSON/REST API available** → fetch data with `httpx2` and generate Pydantic models from
   a sample response using `datamodel-codegen` (see below). Prefer
-  `httpx.AsyncClient` with `asyncio.gather()` for paginated APIs (see
+  `httpx2.AsyncClient` with `asyncio.gather()` for paginated APIs (see
   [Async / concurrent page fetching](#async--concurrent-page-fetching) below).
 - **No public API (Drupal, WordPress, static HTML, etc.)** → use web scraping with
-  `httpx` + `BeautifulSoup` (see [Web-scraping variant](#web-scraping-variant) below).
+  `httpx2` + `BeautifulSoup` (see [Web-scraping variant](#web-scraping-variant) below).
 
 #### 4. Create `<name>_models.py` — Pydantic models for source data
 
@@ -253,9 +253,9 @@ See `server/plugins/eric/bulk_import.py` for an API/JSON reference implementatio
 
 ### HTTP requests: always chain `.raise_for_status()`
 
-When making HTTP requests with `httpx`, chain `.raise_for_status()` directly onto
+When making HTTP requests with `httpx2`, chain `.raise_for_status()` directly onto
 the `.get()` (or `.post()`, etc.) call instead of calling it on a separate line.
-`httpx.Response.raise_for_status()` returns `self`, so the response object is still
+`httpx2.Response.raise_for_status()` returns `self`, so the response object is still
 available for further use:
 
 ```python
@@ -274,8 +274,8 @@ response = client.get(url)   # ← do not do this
 response.raise_for_status()  # ← do not do this
 ```
 
-This applies to both synchronous (`httpx.Client`) and asynchronous
-(`httpx.AsyncClient`) usage.
+This applies to both synchronous (`httpx2.Client`) and asynchronous
+(`httpx2.AsyncClient`) usage.
 
 ---
 
@@ -309,23 +309,23 @@ return None
 ### Async / concurrent page fetching
 
 When a REST API exposes pagination headers (e.g., WordPress REST APIs return
-`X-WP-TotalPages` and `X-WP-Total`), use `httpx.AsyncClient` with
+`X-WP-TotalPages` and `X-WP-Total`), use `httpx2.AsyncClient` with
 `asyncio.gather()` to fetch all pages concurrently instead of looping
 sequentially:
 
 ```python
 import asyncio
 
-import httpx
+import httpx2
 
 
-async def _fetch_page(httpx_async_client: httpx.AsyncClient, params: dict) -> list:
+async def _fetch_page(httpx_async_client: httpx2.AsyncClient, params: dict) -> list:
     return await httpx_async_client.get(API_URL, params=params).raise_for_status().json()
 
 
 async def fetch_all(*, per_page: int = 100, **filters) -> list:
     base_params = {"per_page": per_page, **filters}
-    async with httpx.AsyncClient(follow_redirects=True, timeout=30.0) as httpx_async_client:
+    async with httpx2.AsyncClient(follow_redirects=True, timeout=30.0) as httpx_async_client:
         first = await httpx_async_client.get(API_URL, params={**base_params, "page": 1})
         first.raise_for_status()
         total_pages = int(first.headers.get("X-WP-TotalPages", "1"))
@@ -468,7 +468,7 @@ Fix any issues reported before committing.
 ### Web-scraping variant
 
 Use this when the source site has **no public REST or JSON API** (e.g., Drupal, WordPress,
-or static HTML sites). The pattern uses `httpx` for HTTP fetches and `BeautifulSoup` for
+or static HTML sites). The pattern uses `httpx2` for HTTP fetches and `BeautifulSoup` for
 HTML parsing.
 
 #### Models (`<name>_models.py`)
@@ -511,13 +511,13 @@ class <PluginName>Model(RootModel[list[<PluginName>Item]]):
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.13"
-# dependencies = ["beautifulsoup4", "httpx", "pydantic"]
+# dependencies = ["beautifulsoup4", "httpx2", "pydantic"]
 # ///
 
 from datetime import datetime
 from pathlib import Path
 
-import httpx
+import httpx2
 from bs4 import BeautifulSoup
 
 from server.plugins.<plugin_name>.<plugin_name>_models import (
@@ -535,7 +535,7 @@ def _absolute_url(href: str) -> str:
     return href if href.startswith("http") else BASE_URL + href
 
 
-async def scrape_resource_page(httpx_async_client: httpx.AsyncClient, url: str) -> <PluginName>Item:
+async def scrape_resource_page(httpx_async_client: httpx2.AsyncClient, url: str) -> <PluginName>Item:
     soup = BeautifulSoup(
         (await httpx_async_client.get(url, headers=HEADERS, follow_redirects=True)).raise_for_status().text,
         "html.parser",
@@ -546,7 +546,7 @@ async def scrape_resource_page(httpx_async_client: httpx.AsyncClient, url: str) 
 
 
 async def scrape_search_results(
-    httpx_async_client: httpx.AsyncClient, url: str = SEARCH_URL, max_results: int = MAX_RESULTS
+    httpx_async_client: httpx2.AsyncClient, url: str = SEARCH_URL, max_results: int = MAX_RESULTS
 ) -> list[str]:
     soup = BeautifulSoup(
         (await httpx_async_client.get(url, headers=HEADERS, follow_redirects=True)).raise_for_status().text,
@@ -567,7 +567,7 @@ async def bulk_import(url: str = SEARCH_URL, max_results: int = MAX_RESULTS) -> 
     if cache.exists():
         return <PluginName>Model.model_validate_json(cache.read_text()).root
     items: list[<PluginName>Item] = []
-    async with httpx.AsyncClient(timeout=30) as httpx_async_client:
+    async with httpx2.AsyncClient(timeout=30) as httpx_async_client:
         for resource_url in await scrape_search_results(httpx_async_client, url, max_results):
             items.append(await scrape_resource_page(httpx_async_client, resource_url))
     cache.write_text(<PluginName>Model(root=items).model_dump_json(indent=2))
@@ -611,7 +611,7 @@ Defined in `server/plugins/ome_plugin.py`:
 | Plugin | Directory | Notable Feature |
 |--------|-----------|----------------|
 | ERIC | `server/plugins/eric/` | Most advanced; bulk CSV/JSON import |
-| Early Learning | `server/plugins/early_learning/` | Web scraping (no API); BeautifulSoup + httpx |
+| Early Learning | `server/plugins/early_learning/` | Web scraping (no API); BeautifulSoup + httpx2 |
 | OERCommons | `server/plugins/oercommons/` | Simple JSON transform |
 | Open Library | `server/plugins/openlibrary/` | Linked metadata (two API calls) |
 | Qubes | `server/plugins/qubes/` | XML-to-JSON conversion |

--- a/demo/README.md
+++ b/demo/README.md
@@ -17,7 +17,7 @@ Queries:
 
 ## `ome_demo.py`
 
-Use [FastAPI](https://fastapi.tiangolo.com) and [httpx](https://www.python-httpx.org) to retrieve multiple different open education resources:
+Use [FastAPI](https://fastapi.tiangolo.com) and [httpx2](https://github.com/pydantic/httpx2) to retrieve multiple different open education resources:
 
 1. An image from <https://michmemories.org>
 2. A dataset from <https://github.com/WorldHistoricalGazetteer>

--- a/demo/michigan_mashup.py
+++ b/demo/michigan_mashup.py
@@ -4,7 +4,7 @@
 # requires-python = ">=3.13"
 # dependencies = [
 #   "beautifulsoup4",
-#   "httpx",
+#   "httpx2",
 # ]
 # ///
 
@@ -22,7 +22,7 @@ On macOS, /usr/bin/open will open images in the default image viewer.
 
 import asyncio
 
-import httpx
+import httpx2
 from bs4 import BeautifulSoup
 
 
@@ -48,11 +48,11 @@ def getty(page: str) -> str:
 
 
 async def fetch_text(url: str) -> str:
-    async with httpx.AsyncClient() as httpx_async_client:
+    async with httpx2.AsyncClient() as httpx_async_client:
         try:
             response = await httpx_async_client.get(url)
             return response.check_for_status().text
-        except httpx.HTTPStatusError:
+        except httpx2.HTTPStatusError:
             print(f"Failed to fetch {url}: {response.status_code}")
             raise
 

--- a/demo/ome_demo.py
+++ b/demo/ome_demo.py
@@ -4,7 +4,7 @@
 # requires-python = ">=3.13"
 # dependencies = [
 #   "fastapi",
-#   "httpx",
+#   "httpx2",
 #   "python-multipart",
 # ]
 # ///
@@ -18,7 +18,7 @@ Import FastAPI and use it retrieve multiple different resources
 
 from typing import Annotated
 
-import httpx
+import httpx2
 from fastapi import FastAPI, File, Form, UploadFile
 
 app = FastAPI()
@@ -46,7 +46,7 @@ async def image() -> bytes:
         "https://digitalcollections.detroitpubliclibrary.org/islandora/object"
         "/islandora%3A236607/datastream/IMAGE/view"
     )
-    async with httpx.AsyncClient() as httpx_async_client:
+    async with httpx2.AsyncClient() as httpx_async_client:
         return await httpx_async_client.get(image_url).raise_for_status().content
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 dev = [
   "beautifulsoup4>=4.15",
   "dateparser>=1.4.2",
-  "httpx>=0.28",
+  "httpx2>=2.12",
   "pytest>=9.1.1",
   "pytest-run-parallel>=0.10",
 ]

--- a/scripts/create_newsgroups.py
+++ b/scripts/create_newsgroups.py
@@ -4,7 +4,7 @@
 # requires-python = ">=3.13"
 # dependencies = [
 #     "beautifulsoup4",
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///

--- a/scripts/get_metadata_from_newsgroup.py
+++ b/scripts/get_metadata_from_newsgroup.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#   "httpx",
+#   "httpx2",
 #   "pydantic",
 # ]
 # ///
@@ -12,7 +12,7 @@
 
 from collections.abc import Iterator
 
-import httpx
+import httpx2
 
 from server.plugins.ome_plugin import EducationResource
 
@@ -30,7 +30,7 @@ def get_metadata_from_newsgroup(
         Yield EducationResources containing metadata from the newsgroup.
     """
     url = f"http://localhost:5001/api/channel/{newsgroup}/cards?page_size=1000"
-    for article in httpx.get(url).raise_for_status().json():
+    for article in httpx2.get(url).raise_for_status().json():
         yield EducationResource.model_validate_json(article["body"])
 
 

--- a/scripts/json_viewer.py
+++ b/scripts/json_viewer.py
@@ -4,7 +4,7 @@
 # requires-python = ">=3.9"
 # dependencies = [
 #     "fastapi",
-#     "httpx",
+#     "httpx2",
 #     "jinja2",
 #     "pydantic",
 #     "toga",
@@ -22,7 +22,7 @@ import webbrowser
 from pathlib import Path
 from typing import Any
 
-import httpx
+import httpx2
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse
@@ -113,7 +113,7 @@ if not (json_file := Path(__file__).with_suffix(".json")).exists():
         msg = "Please set the URL environment variable"
         raise ValueError(msg)
 
-    if not (json_payload := httpx.get(url).raise_for_status().json()):
+    if not (json_payload := httpx2.get(url).raise_for_status().json()):
         msg = f"Failed to fetch JSON payload from {url=}"
         raise ValueError(msg)
 

--- a/scripts/scrape_qubes.py
+++ b/scripts/scrape_qubes.py
@@ -3,7 +3,7 @@
 # /// script
 # dependencies = [
 #     "beautifulsoup4",
-#     "httpx",
+#     "httpx2",
 #     "rich",
 # ]
 # ///
@@ -12,7 +12,7 @@ import argparse
 import json
 from collections.abc import Iterator
 
-import httpx
+import httpx2
 from bs4 import BeautifulSoup, Tag
 from rich.console import Console
 from rich.table import Table
@@ -21,7 +21,7 @@ URL = "https://qubeshub.org/community/groups/coursesource/publications"
 
 
 def fetch_page(url: str) -> str:
-    return httpx.get(url, follow_redirects=True).raise_for_status().text
+    return httpx2.get(url, follow_redirects=True).raise_for_status().text
 
 
 def parse_a_metadata_record(item: Tag) -> dict:

--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-import httpx
+import httpx2
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
@@ -29,7 +29,7 @@ from server.utils import (
     get_channel_summary,
 )
 
-unused = httpx
+unused = httpx2
 
 app = FastAPI()
 

--- a/server/plugins/early_learning/bulk_import.py
+++ b/server/plugins/early_learning/bulk_import.py
@@ -3,14 +3,14 @@
 # Source: https://www.earlylearningresourcenetwork.org/books/search?f%5B0%5D=language%3A712
 #
 # The Early Learning Resource Network site does not expose a public REST or JSON API.
-# This module uses web scraping (httpx + BeautifulSoup) to gather metadata from the
+# This module uses web scraping (httpx2 + BeautifulSoup) to gather metadata from the
 # first 8 English-language resources listed on the search results page.
 
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
 #     "beautifulsoup4",
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -19,7 +19,7 @@ import asyncio
 from datetime import datetime
 from pathlib import Path
 
-import httpx
+import httpx2
 from bs4 import BeautifulSoup
 
 from server.plugins.early_learning.early_learning_models import (
@@ -68,7 +68,7 @@ def _text_list(soup: BeautifulSoup, selector: str) -> list[str]:
 
 
 async def scrape_resource_page(
-    httpx_async_client: httpx.AsyncClient, url: str
+    httpx_async_client: httpx2.AsyncClient, url: str
 ) -> EarlyLearningItem:
     """
     Fetch a single resource page and extract metadata.
@@ -157,7 +157,7 @@ async def scrape_resource_page(
 
 
 async def scrape_search_results(
-    httpx_async_client: httpx.AsyncClient,
+    httpx_async_client: httpx2.AsyncClient,
     url: str = SEARCH_URL,
     max_results: int = MAX_RESULTS,
 ) -> list[str]:
@@ -202,7 +202,7 @@ async def scrape_search_results(
 async def _fetch_all_items(url: str, max_results: int) -> list[EarlyLearningItem]:
     """Async helper that scrapes the search page and each resource page."""
     items: list[EarlyLearningItem] = []
-    async with httpx.AsyncClient(timeout=30) as httpx_async_client:
+    async with httpx2.AsyncClient(timeout=30) as httpx_async_client:
         resource_urls = await scrape_search_results(
             httpx_async_client, url, max_results
         )

--- a/server/plugins/eric/bulk_import.py
+++ b/server/plugins/eric/bulk_import.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -24,7 +24,7 @@ import json
 from collections.abc import Iterator
 from pathlib import Path
 
-from httpx import Client
+from httpx2 import Client
 
 from server.plugins.eric.plugin import EricPlugin
 from server.plugins.ome_plugin import EducationResource

--- a/server/plugins/eric/fetch_eric_open_records.py
+++ b/server/plugins/eric/fetch_eric_open_records.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.9"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 # ]
 # ///
 
@@ -18,7 +18,7 @@ ERIC_open_records.csv must exist in the same directory as this script.
 import csv
 from pathlib import Path
 
-from httpx import AsyncClient
+from httpx2 import AsyncClient
 
 here = Path(__file__).parent
 

--- a/server/plugins/eric/old_eric_models.py
+++ b/server/plugins/eric/old_eric_models.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     import json
     from pathlib import Path
 
-    from httpx import Client
+    from httpx2 import Client
 
     here = Path(__file__).resolve().parent
     # Conditionally create an eric.json file that should contain multiple items (docs).

--- a/server/plugins/mit_opencourseware/bulk_import.py
+++ b/server/plugins/mit_opencourseware/bulk_import.py
@@ -7,7 +7,7 @@
 # requires-python = ">=3.13"
 # dependencies = [
 #     "beautifulsoup4",
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -19,7 +19,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from urllib.parse import urljoin
 
-import httpx
+import httpx2
 from bs4 import BeautifulSoup
 
 from server.plugins.mit_opencourseware.mit_opencourseware_models import (
@@ -40,8 +40,10 @@ logger = logging.getLogger(__name__)
 plugin = MITOpenCourseWarePlugin()
 
 
-def _status_code_from_http_error(exc: httpx.HTTPError) -> str | int:
-    return exc.response.status_code if isinstance(exc, httpx.HTTPStatusError) else "N/A"
+def _status_code_from_http_error(exc: httpx2.HTTPError) -> str | int:
+    return (
+        exc.response.status_code if isinstance(exc, httpx2.HTTPStatusError) else "N/A"
+    )
 
 
 def _normalize_course_url(href: str) -> str:
@@ -188,12 +190,12 @@ def parse_course_page(html: str, listing: MITOCWCourseListing) -> MITOCWCourse:
 
 
 async def _fetch_json_list(
-    httpx_async_client: httpx.AsyncClient, url: str
+    httpx_async_client: httpx2.AsyncClient, url: str
 ) -> list[dict[str, object]]:
     try:
         response = await httpx_async_client.get(url)
         response.raise_for_status()
-    except httpx.HTTPError as exc:
+    except httpx2.HTTPError as exc:
         status_code = _status_code_from_http_error(exc)
         msg = (
             f"Failed to fetch MIT OpenCourseWare JSON from {url} "
@@ -203,11 +205,11 @@ async def _fetch_json_list(
     return response.json()
 
 
-async def _fetch_text(httpx_async_client: httpx.AsyncClient, url: str) -> str:
+async def _fetch_text(httpx_async_client: httpx2.AsyncClient, url: str) -> str:
     try:
         response = await httpx_async_client.get(url)
         response.raise_for_status()
-    except httpx.HTTPError as exc:
+    except httpx2.HTTPError as exc:
         status_code = _status_code_from_http_error(exc)
         msg = (
             f"Failed to fetch MIT OpenCourseWare page {url} "
@@ -218,14 +220,14 @@ async def _fetch_text(httpx_async_client: httpx.AsyncClient, url: str) -> str:
 
 
 async def fetch_topic_index(
-    httpx_async_client: httpx.AsyncClient,
+    httpx_async_client: httpx2.AsyncClient,
 ) -> list[MITOCWTopicIndexItem]:
     payload = await _fetch_json_list(httpx_async_client, MIT_OCW_TOPICS_INDEX_URL)
     return [MITOCWTopicIndexItem.model_validate(item) for item in payload]
 
 
 async def fetch_topic_course_listings(
-    httpx_async_client: httpx.AsyncClient, topic_file: str
+    httpx_async_client: httpx2.AsyncClient, topic_file: str
 ) -> list[MITOCWCourseListing]:
     payload = await _fetch_json_list(
         httpx_async_client, urljoin(MIT_OCW_TOPIC_URL_PREFIX, topic_file)
@@ -234,7 +236,7 @@ async def fetch_topic_course_listings(
 
 
 async def _collect_unique_course_listings(
-    httpx_async_client: httpx.AsyncClient,
+    httpx_async_client: httpx2.AsyncClient,
 ) -> list[MITOCWCourseListing]:
     listings_by_url: dict[str, MITOCWCourseListing] = {}
     for topic in await fetch_topic_index(httpx_async_client):
@@ -254,7 +256,7 @@ async def _collect_unique_course_listings(
 
 
 async def fetch_course_details(
-    httpx_async_client: httpx.AsyncClient, listing: MITOCWCourseListing
+    httpx_async_client: httpx2.AsyncClient, listing: MITOCWCourseListing
 ) -> MITOCWCourse:
     html = await _fetch_text(httpx_async_client, _normalize_course_url(listing.href))
     return parse_course_page(html, listing)
@@ -264,7 +266,7 @@ async def search_courses(
     query: str = DEFAULT_QUERY,
     limit: int = DEFAULT_LIMIT,
 ) -> list[MITOCWCourse]:
-    async with httpx.AsyncClient(
+    async with httpx2.AsyncClient(
         follow_redirects=True,
         timeout=30.0,
     ) as httpx_async_client:

--- a/server/plugins/oapen_books/bulk_import.py
+++ b/server/plugins/oapen_books/bulk_import.py
@@ -12,7 +12,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -23,7 +23,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-import httpx
+import httpx2
 
 from server.plugins.oapen_books.oapen_models import OapenItem, OapenSearchResponse
 from server.plugins.oapen_books.plugin import OapenBooksPlugin
@@ -62,16 +62,16 @@ async def fetch_books(
         "offset": offset,
         "expand": "metadata",
     }
-    async with httpx.AsyncClient(
+    async with httpx2.AsyncClient(
         follow_redirects=True, timeout=30.0
     ) as httpx_async_client:
         try:
             response = await httpx_async_client.get(OAPEN_REST_URL, params=params)
             response.raise_for_status()
-        except httpx.HTTPError as exc:
+        except httpx2.HTTPError as exc:
             status_code = (
                 exc.response.status_code
-                if isinstance(exc, httpx.HTTPStatusError)
+                if isinstance(exc, httpx2.HTTPStatusError)
                 else "N/A"
             )
             msg = (

--- a/server/plugins/oer_africa/bulk_import.py
+++ b/server/plugins/oer_africa/bulk_import.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -16,7 +16,7 @@ import json
 from collections.abc import Iterator
 from pathlib import Path
 
-import httpx
+import httpx2
 
 from server.plugins.oer_africa.oer_africa_models import OERAFricaResource
 from server.plugins.oer_africa.plugin import OERAFricaPlugin
@@ -49,7 +49,7 @@ def bulk_translate_to_json(resources: list[dict]) -> str:
 
 
 async def _fetch_raw(url: str) -> str:
-    async with httpx.AsyncClient() as httpx_async_client:
+    async with httpx2.AsyncClient() as httpx_async_client:
         response = await httpx_async_client.get(url)
         response.raise_for_status()
         return response.text

--- a/server/plugins/oer_africa/plugin.py
+++ b/server/plugins/oer_africa/plugin.py
@@ -3,7 +3,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -13,7 +13,7 @@ import re
 from datetime import UTC, datetime
 from types import MappingProxyType
 
-import httpx
+import httpx2
 
 from server.plugins.oer_africa.oer_africa_models import OERAFricaResource
 from server.plugins.ome_plugin import EducationResource, OMEPlugin
@@ -119,7 +119,7 @@ class OERAFricaPlugin(OMEPlugin):
         json_url = url if "_format=json" in url else f"{url.rstrip('/')}?_format=json"
 
         async def _fetch() -> str:
-            async with httpx.AsyncClient() as httpx_async_client:
+            async with httpx2.AsyncClient() as httpx_async_client:
                 response = await httpx_async_client.get(json_url)
                 response.raise_for_status()
                 return response.text

--- a/server/plugins/oercommons/bulk_import.py
+++ b/server/plugins/oercommons/bulk_import.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -24,7 +24,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-import httpx
+import httpx2
 from pydantic import ValidationError
 
 from server.plugins.oercommons.plugin import OERCommonsPlugin
@@ -59,14 +59,14 @@ def fetch_materials(
     """
     params = {"q": query, "batch_size": batch_size}
     try:
-        with httpx.Client(follow_redirects=True, timeout=30.0) as httpx_client:
+        with httpx2.Client(follow_redirects=True, timeout=30.0) as httpx_client:
             response = httpx_client.get(
                 OERCOMMONS_SEARCH_URL, params=params
             ).raise_for_status()
-    except httpx.HTTPError as exc:
+    except httpx2.HTTPError as exc:
         status_code = (
             exc.response.status_code
-            if isinstance(exc, httpx.HTTPStatusError)
+            if isinstance(exc, httpx2.HTTPStatusError)
             else "N/A"
         )
         msg = (

--- a/server/plugins/open_education_network/bulk_import.py
+++ b/server/plugins/open_education_network/bulk_import.py
@@ -9,7 +9,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -19,7 +19,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-import httpx
+import httpx2
 from pydantic import ValidationError
 
 from server.plugins.ome_plugin import EducationResource
@@ -85,13 +85,13 @@ def fetch_textbooks(
         params["format[]"] = formats
 
     try:
-        with httpx.Client(follow_redirects=True, timeout=30.0) as httpx_client:
+        with httpx2.Client(follow_redirects=True, timeout=30.0) as httpx_client:
             response = httpx_client.get(OEN_TEXTBOOKS_API_URL, params=params)
             response.raise_for_status()
-    except httpx.HTTPError as exc:
+    except httpx2.HTTPError as exc:
         status_code = (
             exc.response.status_code
-            if isinstance(exc, httpx.HTTPStatusError)
+            if isinstance(exc, httpx2.HTTPStatusError)
             else "N/A"
         )
         msg = (

--- a/server/plugins/openlibrary/bulk_import.py
+++ b/server/plugins/openlibrary/bulk_import.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -24,7 +24,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-import httpx
+import httpx2
 
 from server.plugins.ome_plugin import EducationResource
 from server.plugins.openlibrary.plugin import OpenLibraryPlugin
@@ -55,14 +55,14 @@ def fetch_books(
     """
     params = {"q": query, "limit": limit}
     try:
-        with httpx.Client(follow_redirects=True, timeout=30.0) as httpx_client:
+        with httpx2.Client(follow_redirects=True, timeout=30.0) as httpx_client:
             response = httpx_client.get(
                 OPENLIBRARY_SEARCH_URL, params=params
             ).raise_for_status()
-    except httpx.HTTPError as exc:
+    except httpx2.HTTPError as exc:
         status_code = (
             exc.response.status_code
-            if isinstance(exc, httpx.HTTPStatusError)
+            if isinstance(exc, httpx2.HTTPStatusError)
             else "N/A"
         )
         msg = (

--- a/server/plugins/openstax/bulk_import.py
+++ b/server/plugins/openstax/bulk_import.py
@@ -4,7 +4,7 @@
 # requires-python = ">=3.13"
 # dependencies = [
 #     "beautifulsoup4",
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -16,7 +16,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from urllib.parse import urljoin
 
-import httpx
+import httpx2
 from bs4 import BeautifulSoup
 
 from server.plugins.ome_plugin import EducationResource
@@ -131,15 +131,15 @@ async def fetch_subject_page(url: str = COMPUTER_SCIENCE_SUBJECT_URL) -> str:
     """
     Fetch OpenStax subject page HTML.
     """
-    async with httpx.AsyncClient(
+    async with httpx2.AsyncClient(
         follow_redirects=True, timeout=30.0
     ) as httpx_async_client:
         try:
             return (await httpx_async_client.get(url)).raise_for_status().text
-        except httpx.HTTPError as exc:
+        except httpx2.HTTPError as exc:
             status_code = (
                 exc.response.status_code
-                if isinstance(exc, httpx.HTTPStatusError)
+                if isinstance(exc, httpx2.HTTPStatusError)
                 else "N/A"
             )
             msg = (

--- a/server/plugins/prelinger/bulk_import.py
+++ b/server/plugins/prelinger/bulk_import.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///

--- a/server/plugins/prelinger/fetch_prelinger_videos.py
+++ b/server/plugins/prelinger/fetch_prelinger_videos.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -30,7 +30,7 @@ Results are cached in ``prelinger_finland_videos.json`` inside this directory.
 
 from pathlib import Path
 
-import httpx
+import httpx2
 
 from server.plugins.prelinger.plugin import PrelingerPlugin
 from server.plugins.prelinger.prelinger_models import (
@@ -55,7 +55,7 @@ def search_prelinger(
     query: str,
     rows: int = 50,
     *,
-    httpx_client: httpx.Client,
+    httpx_client: httpx2.Client,
 ) -> list[str]:
     """
     Search the Prelinger collection and return a list of item identifiers.
@@ -77,7 +77,7 @@ def search_prelinger(
 
 
 def fetch_item_metadata(
-    identifier: str, *, httpx_client: httpx.Client
+    identifier: str, *, httpx_client: httpx2.Client
 ) -> PrelingerItem:
     """
     Fetch the full metadata for a single Prelinger item via the md-read API.
@@ -106,7 +106,7 @@ def bulk_import(query: str = "finland", rows: int = 50) -> list[PrelingerItem]:
         return PrelingerModel.model_validate_json(cache_path.read_text()).root
 
     items: list[PrelingerItem] = []
-    with httpx.Client(follow_redirects=True, timeout=30.0) as httpx_client:
+    with httpx2.Client(follow_redirects=True, timeout=30.0) as httpx_client:
         identifiers = search_prelinger(query, rows=rows, httpx_client=httpx_client)
         for identifier in identifiers:
             item = fetch_item_metadata(identifier, httpx_client=httpx_client)

--- a/server/plugins/prelinger/plugin.py
+++ b/server/plugins/prelinger/plugin.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 from datetime import datetime
 from types import MappingProxyType
 
-import httpx
+import httpx2
 
 from server.plugins.ome_plugin import EducationResource, OMEPlugin
 from server.plugins.prelinger.prelinger_models import (
@@ -99,7 +99,7 @@ class PrelingerPlugin(OMEPlugin):
         Calls ``GET https://archive.org/metadata/{identifier}`` where
         *identifier* is extracted from the supplied *url*.
         """
-        with httpx.Client(follow_redirects=True, timeout=30.0) as client:
+        with httpx2.Client(follow_redirects=True, timeout=30.0) as client:
             # Accept both https://archive.org/details/{id} and
             # https://archive.org/metadata/{id}
             identifier = url.rstrip("/").rsplit("/", 1)[-1]

--- a/server/plugins/pressbooks/bulk_import.py
+++ b/server/plugins/pressbooks/bulk_import.py
@@ -8,7 +8,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -19,7 +19,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-import httpx
+import httpx2
 from pydantic import ValidationError
 
 from server.plugins.ome_plugin import EducationResource
@@ -61,17 +61,17 @@ def _parse_page(items: list) -> list[PressbooksBook]:
 
 
 async def _fetch_page(
-    httpx_async_client: httpx.AsyncClient,
+    httpx_async_client: httpx2.AsyncClient,
     params: dict[str, str | int],
 ) -> list[PressbooksBook]:
     """Fetch and parse a single page of books from the Pressbooks Directory API."""
     try:
         response = await httpx_async_client.get(BOOKS_API_URL, params=params)
         response.raise_for_status()
-    except httpx.HTTPError as exc:
+    except httpx2.HTTPError as exc:
         status_code = (
             exc.response.status_code
-            if isinstance(exc, httpx.HTTPStatusError)
+            if isinstance(exc, httpx2.HTTPStatusError)
             else "N/A"
         )
         msg = (
@@ -111,7 +111,7 @@ async def fetch_all_books(
     if institution:
         base_params["institution"] = institution
 
-    async with httpx.AsyncClient(
+    async with httpx2.AsyncClient(
         follow_redirects=True, timeout=30.0
     ) as httpx_async_client:
         # Fetch the first page and read the total page count from the response header.
@@ -119,10 +119,10 @@ async def fetch_all_books(
             first_response = await httpx_async_client.get(
                 BOOKS_API_URL, params={**base_params, "page": 1}
             ).raise_for_status()
-        except httpx.HTTPError as exc:
+        except httpx2.HTTPError as exc:
             status_code = (
                 exc.response.status_code
-                if isinstance(exc, httpx.HTTPStatusError)
+                if isinstance(exc, httpx2.HTTPStatusError)
                 else "N/A"
             )
             msg = (

--- a/server/plugins/project_gutenberg/bulk_import.py
+++ b/server/plugins/project_gutenberg/bulk_import.py
@@ -14,7 +14,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -25,7 +25,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-import httpx
+import httpx2
 
 from server.plugins.ome_plugin import EducationResource
 from server.plugins.project_gutenberg.gutenberg_models import (
@@ -68,17 +68,17 @@ async def fetch_books(
     url: str | None = GUTENDEX_BOOKS_URL
     params: dict[str, str | int] = {"search": query}
 
-    async with httpx.AsyncClient(
+    async with httpx2.AsyncClient(
         follow_redirects=True, timeout=API_TIMEOUT_SECONDS
     ) as httpx_async_client:
         while url and len(books) < limit:
             try:
                 response = await httpx_async_client.get(url, params=params)
                 response.raise_for_status()
-            except httpx.HTTPError as exc:
+            except httpx2.HTTPError as exc:
                 status_code = (
                     exc.response.status_code
-                    if isinstance(exc, httpx.HTTPStatusError)
+                    if isinstance(exc, httpx2.HTTPStatusError)
                     else "N/A"
                 )
                 msg = (

--- a/server/plugins/qubes/bulk_import.py
+++ b/server/plugins/qubes/bulk_import.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///

--- a/server/plugins/qubes/utils.py
+++ b/server/plugins/qubes/utils.py
@@ -1,6 +1,6 @@
 # /// script
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "rich",
 # ]
 # ///
@@ -9,7 +9,7 @@ import xml.etree.ElementTree as ET
 from datetime import UTC, datetime
 from urllib.parse import urlparse
 
-import httpx
+import httpx2
 
 from server.plugins.ome_plugin import EducationResource
 
@@ -41,7 +41,7 @@ def license_url_to_spdx_id(url: str) -> str:
 def extract_from_url(url: str) -> EducationResource:
     api_url = f"http://qubeshub.org/oaipmh/?verb=GetRecord&metadataPrefix=qdc&identifier={url}"
     # api_url = f"http://ddev-qubeshub-web:80/oaipmh/?verb=GetRecord&metadataPrefix=qdc&identifier={url}"
-    response = httpx.get(
+    response = httpx2.get(
         api_url,
         follow_redirects=True,
         timeout=30,

--- a/server/plugins/whg/bulk_import.py
+++ b/server/plugins/whg/bulk_import.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -23,7 +23,7 @@ import logging
 from collections.abc import Iterator
 from pathlib import Path
 
-import httpx
+import httpx2
 from pydantic import ValidationError
 
 from server.plugins.ome_plugin import EducationResource
@@ -73,12 +73,12 @@ def fetch_datasets(url: str = WHG_DATASETS_URL) -> list[Feature]:
         A list of :class:`Feature` records.
     """
     try:
-        with httpx.Client(follow_redirects=True, timeout=30.0) as httpx_client:
+        with httpx2.Client(follow_redirects=True, timeout=30.0) as httpx_client:
             response = httpx_client.get(url).raise_for_status()
-    except httpx.HTTPError as exc:
+    except httpx2.HTTPError as exc:
         status_code = (
             exc.response.status_code
-            if isinstance(exc, httpx.HTTPStatusError)
+            if isinstance(exc, httpx2.HTTPStatusError)
             else "N/A"
         )
         msg = (

--- a/server/plugins/whg/whg_models.py
+++ b/server/plugins/whg/whg_models.py
@@ -6,7 +6,7 @@
 # /// script
 # requires-python = ">=3.13"
 # dependencies = [
-#     "httpx",
+#     "httpx2",
 #     "pydantic",
 # ]
 # ///
@@ -52,7 +52,7 @@ if __name__ == "__main__":
     import json
     from pathlib import Path
 
-    from httpx import Client
+    from httpx2 import Client
 
     here = Path(__file__).resolve().parent
     # Conditionally create an whg.json file that should contain whg dataset items.

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,13 +1,13 @@
 """Tests that verify each OME plugin has a documentation page at GitHub Pages.
 
-Uses httpx to check https://iskme.github.io/Open-Metadata-Exchange for
+Uses httpx2 to check https://iskme.github.io/Open-Metadata-Exchange for
 a page for each plugin in the server/plugins directory.
 """
 
 import asyncio
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 
 PLUGINS_DIR = Path(__file__).resolve().parent.parent / "server" / "plugins"
@@ -23,8 +23,8 @@ def _plugin_names() -> list[str]:
     )
 
 
-async def _get(url: str) -> httpx.Response:
-    async with httpx.AsyncClient() as httpx_async_client:
+async def _get(url: str) -> httpx2.Response:
+    async with httpx2.AsyncClient() as httpx_async_client:
         return await httpx_async_client.get(url, follow_redirects=True)
 
 

--- a/tests/test_oer_africa_plugin.py
+++ b/tests/test_oer_africa_plugin.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-import httpx
+import httpx2
 import pytest
 
 from server.plugins.oer_africa.oer_africa_models import OERAFricaResource
@@ -50,9 +50,9 @@ def test_make_metadata_card_from_json() -> None:
 
 
 def test_make_metadata_card_from_url_not_implemented_raises() -> None:
-    """make_metadata_card_from_url raises httpx.ConnectError on an invalid hostname."""
+    """make_metadata_card_from_url raises httpx2.ConnectError on an invalid hostname."""
     plugin = OERAFricaPlugin()
-    with pytest.raises(httpx.ConnectError):
+    with pytest.raises(httpx2.ConnectError):
         plugin.make_metadata_card_from_url(
             "https://www.oerafrica.invalid/node/99999999"
         )

--- a/tests/test_ome_node.py
+++ b/tests/test_ome_node.py
@@ -1,4 +1,4 @@
-# uvx -w=beautifulsoup4,dateparser,httpx,pydantic,pynntp pytest -vv
+# uvx -w=beautifulsoup4,dateparser,httpx2,pydantic,pynntp pytest -vv
 from collections.abc import Generator, Iterator
 from datetime import UTC, datetime
 

--- a/uv.lock
+++ b/uv.lock
@@ -372,58 +372,90 @@ wheels = [
 
 [[package]]
 name = "fastar"
-version = "0.11.0"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/0f/0aeb3fc50046617702acc0078b277b58367fd62eb727b9ec733ae0e8bbcc/fastar-0.11.0.tar.gz", hash = "sha256:aa7f100f7313c03fdb20f1385927ba95671071ba308ad0c1763fef295e1895ce", size = 70238, upload-time = "2026-04-13T17:11:17.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/52/5bee9a672f418008d34c708d66e89e8f6fed8f0812f406a1c92fb5e393a8/fastar-0.12.0.tar.gz", hash = "sha256:bba71522eae6a7627a5514ffdd4ac9645ef27d82e23931d79fd974bb49c3f2ad", size = 89647, upload-time = "2026-08-20T09:11:25.212Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/d6/3be260037e86fb694e88d47f583bac3a0188c99cee1a6b257ac26cb6b53c/fastar-0.11.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:33f544b08b4541b678e53749b4552a44720d96761fb79c172b005b1089c443ed", size = 707975, upload-time = "2026-04-13T17:09:58.866Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/cd/7867aefb1784662554a335f2952c75a50f0c70585ed0d2210d6cc15e5627/fastar-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:91c1c792447e4a642745f347ff9847c52af39633071c57ee67ed53c157fc3506", size = 628460, upload-time = "2026-04-13T17:09:43.776Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2b/d11d84bdd5e0e377771b955755771e3460b290da5809cb78c1b735ee2228/fastar-0.11.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:881247e6b6eaea59fc6569f9b61447aa6b9fc2ee864e048b4643d69c52745805", size = 863054, upload-time = "2026-04-13T17:09:13.048Z" },
-    { url = "https://files.pythonhosted.org/packages/25/39/d3f428b318fa940b1b6e785b8d54fc895dfb5d5b945ef8d5442ffa904fb2/fastar-0.11.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:863b7929845c9fec92ef6c8d59579cf46af5136655e5342f8df5cebe46cab06c", size = 760247, upload-time = "2026-04-13T17:07:57.396Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/04/03949aee82aabb8ede06ac5a4a5579ffaf98a8fe59ce958494508ff15513/fastar-0.11.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96b4a57df12bf3211662627a3ea29d62ecb314a2434a0d0843f9fc23e47536e5", size = 756512, upload-time = "2026-04-13T17:08:12.415Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/0c/2ca1ae0a3828ca51047962d932b80daca2522db73e8cb9d040cb6ebe28d5/fastar-0.11.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ceef1c2c4df7b7b8ebd3f5d718bbf457b9bbdf25ce0bd07870211ec4fbd9aff4", size = 922183, upload-time = "2026-04-13T17:08:27.187Z" },
-    { url = "https://files.pythonhosted.org/packages/65/68/7fe808b1f73a68e686f25434f538c6dc10ef4dfb3db0ace22cd861744bf8/fastar-0.11.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8e545918441910a779659d4759ad0eef349e935fbdb4668a666d3681567eb05", size = 816394, upload-time = "2026-04-13T17:08:57.657Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/17/07d086080f8a83b8d7966955e29bcdbd6a060f5bd949dc9d5abd3658cead/fastar-0.11.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28095bb8f821e85fc2764e1a55f03e5e2876dee2abe7cd0ee9420d929905d643", size = 818983, upload-time = "2026-04-13T17:09:28.46Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e2/2c4edf0910af2e814ff6d65b77a91196d472ca8a9fb2033bd983f6856caa/fastar-0.11.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0fafb95ecbe70f666a5e9b35dd63974ccdc9bb3d99ccdbd4014a823ec3e659b5", size = 884689, upload-time = "2026-04-13T17:08:42.763Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ba/04fdcbd6558e60de4ced3b55230fac47675d181252582b2fcec3c74608e5/fastar-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:af48fed039b94016629dcdad1c95c90c486326dd068de2b0a4df419ee09b6821", size = 970677, upload-time = "2026-04-13T17:10:15.124Z" },
-    { url = "https://files.pythonhosted.org/packages/df/b3/2b860a9658550167dbd5824c85e88d0b4b912bf493e42a6322544d6e483d/fastar-0.11.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:74cd96163f39b8638ab4e8d49708ca887959672a22871d8170d01f067319533b", size = 1034026, upload-time = "2026-04-13T17:10:32.318Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/9b/fa42ea1188b144bac4b1b60753dfd449974a4d5eda132029ee7711569f94/fastar-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4e8b993cb5613bab495ed482810bedc0986633fcb9a3b55c37ec88e0d6714f6a", size = 1071147, upload-time = "2026-04-13T17:10:48.833Z" },
-    { url = "https://files.pythonhosted.org/packages/95/c8/d2e501556dca9f1fbc9246111a31792fb49ad908fa4927f34938a97a3604/fastar-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfe39d91fc28e37e06162d94afe01050220edb7df554acb5b702b5503e564816", size = 1028377, upload-time = "2026-04-13T17:11:06.374Z" },
-    { url = "https://files.pythonhosted.org/packages/db/33/5f11f23eca0a569cd052507bc45dda2e5468697f8665728d25be44120f7d/fastar-0.11.0-cp313-cp313-win32.whl", hash = "sha256:c5f63d4d99ff4bfb37c659982ec413358bdee747005348756cc50a04d412d989", size = 454089, upload-time = "2026-04-13T17:11:46.821Z" },
-    { url = "https://files.pythonhosted.org/packages/da/2f/35ff03c939cba7a255a9132367873fec6c355fd06a7f84fedcbaf4c8129f/fastar-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8690ed1928d31ded3ada308e1086525fb3871f5fa81e1b69601a3f7774004583", size = 486312, upload-time = "2026-04-13T17:11:32.86Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/71/ee9246cbfcbfd4144558f35e7e9a306ffe0a7564730a5188c45f21d2dab8/fastar-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:d977ded9d98a0719a305e0a4d5ee811f1d3e856d853a50acb8ae833c3cd6d5d2", size = 461975, upload-time = "2026-04-13T17:11:22.589Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/cd/3644c48ecac456f928c12d47ec3bed36c36555b17c3859856f1ff860265d/fastar-0.11.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:71375bd6f03c2a43eb47bd949ea38ff45434917f9cdac79675c5b9f60de4fa73", size = 707860, upload-time = "2026-04-13T17:10:00.371Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ca/dee04476ae3626b2b040a60ad84628f77e1ffd8444232f2426b0ca1e0d7e/fastar-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eddfd9cab16e19ae247fe44bf992cb403ccfe27d3931d6de29a4695d95ad386c", size = 628216, upload-time = "2026-04-13T17:09:45.355Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/5e/9395c7353d079cb4f5be0f7982ce0dc9f2e7dec5fd175eef466729d6023a/fastar-0.11.0-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7c371f1d4386c699018bb64eb2fa785feacf32785559049d2bb72fe4af023f53", size = 864378, upload-time = "2026-04-13T17:09:14.611Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ba/1e4f67148223ff219612b6281a6000357abbcc2417964fa5c83f11d68fce/fastar-0.11.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cad7fa41e3e66554387481c1a09365e4638becd322904932674159d5f4046728", size = 760921, upload-time = "2026-04-13T17:07:59.138Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/82/09d11fb6d12f17993ffaf32ffd30c3c121a11e2966e84f19fb6f66430118/fastar-0.11.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cf36652fa71b83761717c9899b98732498f8a2cb6327ff16bbf07f6be85c3437", size = 757012, upload-time = "2026-04-13T17:08:14.186Z" },
-    { url = "https://files.pythonhosted.org/packages/52/1f/5aeeacc4cb65615e2c9292cd9c5b0cd6fb6d2e6ee472ca6adc6c1b1b22ef/fastar-0.11.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f68ff8c17833053da4841720e95edde80ce45bb994b6b7d51418dddaac70ee47", size = 924510, upload-time = "2026-04-13T17:08:28.741Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/1a/1e5bdabbeaf2e856928956292609f2ff6a650f94480fb8afaca30229e483/fastar-0.11.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4563ed37a12ea1cdc398af8571258d24b988bf342b7b3bf5451bd5891243280c", size = 816602, upload-time = "2026-04-13T17:08:59.461Z" },
-    { url = "https://files.pythonhosted.org/packages/87/24/f960147910da3bed41a3adfcb026e17d5f50f4cf467a3324237a7088f61a/fastar-0.11.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cee63c9875cba3b70dc44338c560facc5d6e763047dcc4a30501f9a68cf5f890", size = 819452, upload-time = "2026-04-13T17:09:29.926Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f4/3e77d7901d5707fd7f8a352e153c8ae09ea974e6fabad0b7c4eb9944b8d4/fastar-0.11.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:bd76bfffae6d0a91f4ac4a612f721e7aec108db97dccdd120ae063cd66959f27", size = 885254, upload-time = "2026-04-13T17:08:44.285Z" },
-    { url = "https://files.pythonhosted.org/packages/47/01/1585edd5ec47782ae93cd94edf05828e0ab02ef00aec00aea4194a600464/fastar-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8f5b707501ec01c1bc0518f741f01d322e50c9adc19a451aa24f67a2316e9397", size = 971496, upload-time = "2026-04-13T17:10:17.024Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/e9/6874c9d1236ded565a0bed54b320ac9f165f287b1d89490fb70f9f323c81/fastar-0.11.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:37c0b5a88a657839aad98b0a6c9e4ac4c2c15d6b49c44ee3935c6b08e9d3e479", size = 1034685, upload-time = "2026-04-13T17:10:34.063Z" },
-    { url = "https://files.pythonhosted.org/packages/14/d8/4ab20613ce2983427aee958e39be878dba874aa227c530a845e32429c4f6/fastar-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6c55f536c62a6efb180c1af0d5182948bff576bbfe6276e8e1359c9c7d2215d8", size = 1072675, upload-time = "2026-04-13T17:10:50.53Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/ae/5ac3b7c20ce4b08f011dd2b979f96caabe64f9b10b157f211ea91bdfadca/fastar-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3082eeca59e189b9039335862f4c2780c0c8871d656bfdf559db4414a105b251", size = 1029330, upload-time = "2026-04-13T17:11:08.138Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/e7/37cd6a1d4e288292170b64e19d79ecce2a7de8bb76790323399a2abc4619/fastar-0.11.0-cp314-cp314-win32.whl", hash = "sha256:b201a0a4e29f9fec2a177e13154b8725ec65ab9f83bd6415483efaa2aa18344b", size = 453940, upload-time = "2026-04-13T17:11:48.713Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1c/795c878b1ee29d79021cf8ed81f18f2b25ccde58453b0d34b9bdc7e025ea/fastar-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:868fddb26072a43e870a8819134b9f80ee602931be5a76e6fb873e04da343637", size = 486334, upload-time = "2026-04-13T17:11:34.882Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/a4/113f104301df8bddcc0b3775b611a30cb7610baa3add933c7ccac9386467/fastar-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:3db39c9cc42abb0c780a26b299f24dfbc8be455985e969e15336d70d7b2f833b", size = 461534, upload-time = "2026-04-13T17:11:24.329Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a6/5c5f2c2c8e0c63e56a5636ebc7721589c889e94c0092cec7eb28ae7207e6/fastar-0.11.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:49c3299dec5e125e7ebaa27545714da9c7391777366015427e0ae62d548b442b", size = 707156, upload-time = "2026-04-13T17:10:02.176Z" },
-    { url = "https://files.pythonhosted.org/packages/df/f7/982c01b61f0fc135ad2b16d01e6d0ee53cf8791e68827f5f7c5a65b2e5b1/fastar-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3328ed1ed56d31f5198350b17dd60449b8d6b9d47abb4688bab6aef4450a165b", size = 627032, upload-time = "2026-04-13T17:09:46.978Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c3/38f1dac77ae0c71c37b176277c96d830796b8ce2fe69705f917829b53829/fastar-0.11.0-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd3eca3bbfec84a614bcb4143b4ad4f784d0895babc26cfc88436af88ca23c7a", size = 864403, upload-time = "2026-04-13T17:09:16.58Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f0/e69c363bdb3e5a5848e937b662b5469581ee6682c51bc1c0556494773929/fastar-0.11.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff86a967acb0d621dd24063dda090daa67bf4993b9570e97fe156de88a9006ca", size = 759480, upload-time = "2026-04-13T17:08:00.599Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/29/4d8737590c2a6357d614d7cc7288e8f68e7e449680b8922997cc4349e65e/fastar-0.11.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:86eaf7c0e985d93a7734168be2fb232b2a8cca53e41431c2782d7c12b12c03b1", size = 756219, upload-time = "2026-04-13T17:08:15.699Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ec/400de7b3b7d48801908f19cf5462177104395799472671b3e8152b2b04ca/fastar-0.11.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91f07b0b8eb67e2f177733a1f884edad7dfb9f8977ffef15927b20cb9604027d", size = 923669, upload-time = "2026-04-13T17:08:30.574Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/01/8926c53da923fed7ab4b96e7fbf7f73b663beb4f02095b654d6fab46f9ad/fastar-0.11.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f85c896885eb4abf1a635d54dea22cac6ae48d04fc2ea26ae652fcf1febe1220", size = 815729, upload-time = "2026-04-13T17:09:01.204Z" },
-    { url = "https://files.pythonhosted.org/packages/89/f0/5fef4c7946e352651b504b1a4235dac3505e7cfd24020788ab50552e84bf/fastar-0.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:075c07095c8de4b774ba8f28b9c0a02b1a2cd254da50cbe464dd3bb2432e9158", size = 819812, upload-time = "2026-04-13T17:09:31.907Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/c8/0ebc3298b4a45e7bddc50b169ae6a6f5b80c939394d4befe6e60de535ee7/fastar-0.11.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:07f028933820c65750baf3383b807ecce1cd9385cf00ce192b79d263ad6b856c", size = 884074, upload-time = "2026-04-13T17:08:45.802Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/9f/7baa4cdff8d6fbca41fa5c764b48a941fed8a9ec6c4cc92de65895a28299/fastar-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:039f875efa0f01fa43c20bf4e2fc7305489c61d0ac76eda991acfba7820a0e63", size = 969450, upload-time = "2026-04-13T17:10:18.667Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/dc/1ebbfb58a47056ba866494f19efbcdd2ba2897096b94f36e796594b4d05b/fastar-0.11.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:fff12452a9a5c6814a012445f26365541cc3d99dcca61f09762e6a389f7a32ea", size = 1033775, upload-time = "2026-04-13T17:10:36.165Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/5f/ce4e3914066f08c99eb8c32952cc07c1a013e81b1db1b0f598130bf6b974/fastar-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2bf733e09f942b6fa876efe30a90508d1f4caef5630c00fb2a84fba355873712", size = 1072158, upload-time = "2026-04-13T17:10:52.497Z" },
-    { url = "https://files.pythonhosted.org/packages/03/2a/6bca72992c84151c387cc6558f3867f5ebe5fb3684ee6fa9b76280ba4b8e/fastar-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d1531fa848fdd3677d2dce0a4b436ea64d9ae38fb8babe2ddbc180dd153cb7a3", size = 1028577, upload-time = "2026-04-13T17:11:09.934Z" },
-    { url = "https://files.pythonhosted.org/packages/83/18/7a7c15657a3da5569b26fc51cde6a80f8d84cb54b3b1aea6d74a103db4ad/fastar-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:5744551bc67c6fc6581cbd0e34a0fd6e2cd0bd30b43e94b1c3119cf35064b162", size = 453601, upload-time = "2026-04-13T17:11:53.726Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/d8/331b59a6de279f3ad75c10c02c40a12f21d64a437d9c3d6f1af2dcbd7a76/fastar-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f4ce44e3b56c47cf38244b98d29f269b259740a580c47a2552efa5b96a5458fb", size = 486436, upload-time = "2026-04-13T17:11:40.089Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fd/5390ec4f49100f3ecb9968a392f9e6d039f1e3fe0ecd28443716ff01e589/fastar-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:76c1359314355eafbc6989f20fb1ad565a3d10200117923b9da765a17e2f6f11", size = 461049, upload-time = "2026-04-13T17:11:25.918Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ee/bfce95bdf2bd61a1e311c7181e0ff99c39a6eebe4ca2bfd2d04eb403970b/fastar-0.12.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:654165090cdcac7ff13d43ee4012c366f0f2061ddf46658bc0ad248c8aa3960a", size = 697138, upload-time = "2026-08-20T09:09:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b0/dd24d87b58b4e99257ff0b0a53b60c89b0a32e89bd33c1f966e9bda58ad3/fastar-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:685d3d45943b43c32c71c8470552a615c90e06ca532db1b7a5633f01aa108f0d", size = 623873, upload-time = "2026-08-20T09:09:36.361Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/00/abacbfa2e94c1ff4b717e07ae2e5521ba84804884ff51f18f01706d024cf/fastar-0.12.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f8da75b5eca0d3b540e50ab6b7dfe4b148d7ae8a0b444a9781fd1219392859a0", size = 855719, upload-time = "2026-08-20T09:09:01.612Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/27/2781690ebabbce0d2a25b9efd359a13a5df2b0098120167e58b013c9f65a/fastar-0.12.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13c2df8db1b7a4d783429ffa1125c53f7dd9534baae7218eb49273797691e2a8", size = 754159, upload-time = "2026-08-20T09:07:31.365Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9b/1e6262fe31b2e8efc90feacf3f2213c9d2dff5fcb6e88f9084f26f18d62e/fastar-0.12.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:042fd43c4e0c3f3ba3f7b8a083694d1c4bd77d60ce266090d4eb96cb8a8021c2", size = 748002, upload-time = "2026-08-20T09:07:48.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8e/b4792568d3e544b4e2b00b918744e4edb7e8c6be3c4fce268514febeb844/fastar-0.12.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6958a332c55052dd8090b03de238ca59190d625f4ba9c292b34e938ac64105ea", size = 915919, upload-time = "2026-08-20T09:08:07.102Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3f/0460223969f5dae9a49d09a29a93d5ccc359e701b0a18c0972a0ebce29b1/fastar-0.12.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6b05c0c739c43b9228e57fc59eb68c38660c62030bcdea3a032b269df71f5bb8", size = 807788, upload-time = "2026-08-20T09:08:42.967Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7b/68e681a12232ca2dc46d7d6de0c0fbe770137a204e4a3c0b5864a9548d67/fastar-0.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2bfad69679111e4567d4bad41fd795071c9335cd94bc0f26e24b7d19e95c9b1", size = 807587, upload-time = "2026-08-20T09:09:19.304Z" },
+    { url = "https://files.pythonhosted.org/packages/81/8f/f93e981114034eb901d301690ad8e21edca6a2307b380d5e20e4e4862c7d/fastar-0.12.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:1155e1dd9c60cf636b6b3d35edfe242348f47286724fa84b5b4055c03d7fdbf6", size = 874095, upload-time = "2026-08-20T09:08:25.707Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8e/74671e6cc6d9056347806ed9eefd0ea0bda25292848b32cc8cc321f956d8/fastar-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:29b87474b2e7c9e64549b87aeb2c1d68a94e78c887a3a8d88bf7b804ddbcc0dc", size = 965017, upload-time = "2026-08-20T09:10:12.048Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/55/44d5c532bfdbff48f3f6ce957744a612f7a169af9e4a673f00e21f8c83ed/fastar-0.12.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:4587a08d6de2e62611278fc4cd36186a3ebbf6609d9e49df34d79a407d66f599", size = 1024377, upload-time = "2026-08-20T09:10:31.936Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/35/73d04733a06175211fef985f4e89604882b849cf1125c4a792ef022aa85c/fastar-0.12.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e7d7512b5c747edfce129448a72c8f6223323748ca3e98cc54401241bff70ee5", size = 1061994, upload-time = "2026-08-20T09:10:52.014Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/c841b941fad02b5fc6e2277fc8ca35d963685fafc9335b76925bd166d11a/fastar-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ce9a7e7757074a3d0920a8bc3936cf4164f63786d8e1b64e425d2957ddcceace", size = 1018409, upload-time = "2026-08-20T09:11:11.495Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c8/59a1791df4f128e6f8fffa03fd46d9b6c8ca24bcb6b7e9071973648edab3/fastar-0.12.0-cp313-cp313-win32.whl", hash = "sha256:61f1eec258b328182c6b6258641d33264ac3080fb7fcbf40ea1e326fc855d917", size = 450302, upload-time = "2026-08-20T09:12:00.704Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/9e/483982c1e60e3d9332c3b870230b34404b5b44340d647a97fe8f91d4fa0f/fastar-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:84caa362865cac75807c51afbeff2e9b313fc45f89e0865f7c8bf627ea721f4b", size = 482104, upload-time = "2026-08-20T09:11:43.655Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e6/ec8ab1d44d73c0cad4f9e0ae4ce7b9330f2d504f835774802845dd465a42/fastar-0.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:a3de985d942247fa924e185ff2744a6da0005dcedbb39ae1b811bec11710e572", size = 458292, upload-time = "2026-08-20T09:11:29.693Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f9/cf4b63a3b8bfa7dba8de8db364246d9e8390108a789de3f6a9628bb75c8a/fastar-0.12.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:7116a770a4e47262734fafe06d3e835a23b833e81b45b3054558301385a0f2a7", size = 698042, upload-time = "2026-08-20T09:09:55.257Z" },
+    { url = "https://files.pythonhosted.org/packages/be/3f/c0ef2beffeeb01f9ec27b0ba8ce23697919b2247316d923f5a3bed6fc26b/fastar-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ebe324ffcb3e8efb2308255f60de911bfa4ccf10f087b6e60c62606f091f1807", size = 626452, upload-time = "2026-08-20T09:09:37.853Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/32/87c1887bcbe311a913a2b5b2f4481cce9bae7dd05115575c9f6cbbc892f5/fastar-0.12.0-cp314-cp314-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4af6be78f7ec6ef8e6da7d162361e4198be10fe81bfc95112f635c2c14e12922", size = 856780, upload-time = "2026-08-20T09:09:03.181Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d3/d4299d3c73df485d2bf095cca7e3829036f6a3fce26728ccfe4c3db3798b/fastar-0.12.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad38b27e93ba9c7de076ad694d224153bf8d66695acc27a114cba8087078fd54", size = 755380, upload-time = "2026-08-20T09:07:32.822Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ff/768ec3c6898fb20710ab222b8bc7caedcb9765a4c78122bb0267373f8255/fastar-0.12.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:968d64c203d10d257c2f2268cfc97d94f273fdfc64b37a4739fdb6e2cf2c3f03", size = 748975, upload-time = "2026-08-20T09:07:50.575Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7c/0ea040fdd20fe90c39e008f5c8b54b54058afb78faf261484c67b4ea5e94/fastar-0.12.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21256ccb3946730e3d601b6a9c9de61a127855957a7f0852cb14b0dbe15f8aeb", size = 917534, upload-time = "2026-08-20T09:08:08.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/5d/5a46751dff921b344ce995ee364801a867d80331406a96215336140182ed/fastar-0.12.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15d89116b102fb7d4c47b6b723dc32d5c12122e7ffeb41b7a8b22cc777c9eca5", size = 808943, upload-time = "2026-08-20T09:08:44.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/67/6336def57f2b4701f93289a999a42de7743dfb78320a6b8931e9c0472da4/fastar-0.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1450e0325897e87594c29837fdd9e338b1d281f6c81d14d7a75b6776285b5b6e", size = 809624, upload-time = "2026-08-20T09:09:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/75/bd2540d70c6e4deeae3693cd41725dc42d4a96ced0394a9f845ac6afe148/fastar-0.12.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:ca63fee43f07408efec09e1c0ae34a1b29ae52b8c1adc31bd6434ccc9e1741cb", size = 874787, upload-time = "2026-08-20T09:08:27.198Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5c/13d20ec4d2c1e5ee15bf3b01fa43b282ff93f481d162e5ab507d8a341fbf/fastar-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fa5fd057b4f4537f04dd4e4f13be92433bf47bc479309335755531c5af34560", size = 966646, upload-time = "2026-08-20T09:10:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/6e/fcecbb90c6784ca0d5a54a9c3f7edf78ae5393c71b8dd0088130c3a4c82a/fastar-0.12.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:4b395c3d4375809d0d55b5ae297f6bc037b90b382f35f056e453732e4f6f523c", size = 1025855, upload-time = "2026-08-20T09:10:33.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/8f/e865bf29f54c93a6fee55c7248ae64de91e0c68c6ce7f9a6d8c4adff471d/fastar-0.12.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:20d5e52c45e75a55ed27e7952487506269e9a64559d6cbfaf6977529db81298f", size = 1063126, upload-time = "2026-08-20T09:10:53.804Z" },
+    { url = "https://files.pythonhosted.org/packages/42/19/4010752bcd7f7f290476fd4eec5f9611324b78a00575ad7224b4375fa124/fastar-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4497098ebdf3c1f89dbeafe44ebcd7f143f8a774641bbfa13d1d793104464c41", size = 1019854, upload-time = "2026-08-20T09:11:13.219Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/9dc92104a021396d2cef2d7d3a8a8db2f3409bc19f41a7e8370642e980f8/fastar-0.12.0-cp314-cp314-win32.whl", hash = "sha256:56cb3b3c46edf26f054f2420573c7c69c03997203a7a867ca835bc305b4a0f30", size = 451451, upload-time = "2026-08-20T09:12:02.371Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a7/b2f55b50aa446958225360a20a16a87a4717c2deeda4ebc85edc62b58f64/fastar-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:81534df96e775ccaa37fcd1f45e06f48c245ff77e30d3bcb0d3c1101da9399e8", size = 483614, upload-time = "2026-08-20T09:11:45.439Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0b/eb965694e157e09aa92857db73dd46d7cb10c24dae261a50dc46e0d361e2/fastar-0.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:fce60bd91fd982bf52e9a4c87820a44f92ac0d896bd64544891d6995fa6b8b98", size = 459422, upload-time = "2026-08-20T09:11:31.659Z" },
+    { url = "https://files.pythonhosted.org/packages/31/21/58b9e84b20c50d8cbd31d25aa99ce852a463e60c8f88b3a44bfcdecb46da/fastar-0.12.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:22c882f1096199d5e63f3ea4d9313e10799fcbc70166d315aa07576148601326", size = 696156, upload-time = "2026-08-20T09:09:56.953Z" },
+    { url = "https://files.pythonhosted.org/packages/05/84/227ad56548f2de419a5fb948cedc866ae0aec6fa0cf057b50e96e50aebb8/fastar-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:74c928183d7ca19056bc0eb24d8c1907c115cfb2382ad4a7c32ccbfb04ca0a0b", size = 624449, upload-time = "2026-08-20T09:09:39.39Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/51/8b05253149a568bc62b9a2d774f26a4b963dd91dae3da4e843a2cb7c5b40/fastar-0.12.0-cp314-cp314t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f1f3e70447f45e54b488eea8bd401cd3774b7b688d5b507915ae415058d8ac86", size = 855891, upload-time = "2026-08-20T09:09:04.968Z" },
+    { url = "https://files.pythonhosted.org/packages/02/77/e62ef58301d2d79d624fc17fdaaee61c1a827d5f4000a8482be6a20bd10c/fastar-0.12.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:96ae27bbb807e39e05097bdc2a6cba6820f31dd053aaf8cf0a045e5969041778", size = 754529, upload-time = "2026-08-20T09:07:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/af/87/c35f3c3effae445d1b51b56ad6629df6d2001aeb5051646d081904be2081/fastar-0.12.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0d60682ed24fc6063b18e76a947f1cc0fcd0777709357b801b3e3458a87c2e5", size = 747923, upload-time = "2026-08-20T09:07:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/85/e9556fbaa8183db72c6d3cffdb56384299b2bd4d7a5e0eb990401ea221a0/fastar-0.12.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:644f6d06e312bc47dd315aa36fba723854859601e184113de7b887613ed9a5ad", size = 917040, upload-time = "2026-08-20T09:08:10.474Z" },
+    { url = "https://files.pythonhosted.org/packages/53/8f/9a53202c1dcb3a5cd5661c04c201bff358919f23f6506e73533411cd96d4/fastar-0.12.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea6c5addb01f206bd75f784540a8a11bbddc451293318a823e3fecaf0d62cc3c", size = 808402, upload-time = "2026-08-20T09:08:46.871Z" },
+    { url = "https://files.pythonhosted.org/packages/07/aa/6a083aa6f7089f5ee7cfa99f15f299658953074035a6b7ed4dd52e21b8fe/fastar-0.12.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc892486eb242ac55dde185d547d2723289da50c6cdc06614868416576ba5c4f", size = 809412, upload-time = "2026-08-20T09:09:22.5Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3e/1c45d7da2e67134f161c25f733ba231df67fdcdd018ceb9aecc50feb01d6/fastar-0.12.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a47a68d1b9bd59062af41d9809a340739ab1ba13cb5b4beb23466a621d6479f2", size = 874673, upload-time = "2026-08-20T09:08:28.874Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7f/c56ddd4e7c9035170b4513c2cd24673a4ce7a2a6b6cb9a18970672e14455/fastar-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a7d9fd762e7eab2262ec004aa9c714b53d303e11cca7c814b7b634d9d2424691", size = 965952, upload-time = "2026-08-20T09:10:15.447Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5a/329cca10ae74a8b40791dd59868276e66d9e9321d1c1c4f1284e6c864f9d/fastar-0.12.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3766bf0aeeb6a03d114b185472593a2a3f0ff43f1b56c40fe0cda4283f9f4351", size = 1024392, upload-time = "2026-08-20T09:10:35.46Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ec/3c6bda956cd88d22ed9cb3fdc15e43a6fccf58ac64b8856f5aebd23117c8/fastar-0.12.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:860516a52a3bdcaa746be42fc1bdbbbd48e05c7579f9f61e30d78a7e065835bd", size = 1062506, upload-time = "2026-08-20T09:10:55.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e1/bfb903579672ae213f5c81a5d289e3b9ca92ff2b3f789b08577de5f51050/fastar-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb75898c166ff6d232bceb68a5a7dc4a8f17239fb40925d169649a3967b76c4a", size = 1019468, upload-time = "2026-08-20T09:11:14.932Z" },
+    { url = "https://files.pythonhosted.org/packages/61/46/c0f6a5b18981425879938fdf8ae38dfe7ef031d7164cb5b40eec29e5a4a3/fastar-0.12.0-cp314-cp314t-win32.whl", hash = "sha256:c5755332572756061b29766a9ceff2c837d52d96828e58f908cb46cc49123bd7", size = 449931, upload-time = "2026-08-20T09:12:08.865Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8f/832c7ca0d28642d5869a1aa194e4fb644bae2013101a1e9357168e6e1383/fastar-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:07d861c7ddf31bccb9615a0ba4c9f06987d1373a6b357183526d68cf9c3f5552", size = 482560, upload-time = "2026-08-20T09:11:52.086Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/10/17b9b24e129dcf3f4b4eb57b148888b128930180e9babd0e166cc828b2b6/fastar-0.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b1d56e2a52bebd3e379d0cacc2b018b819a0b99f0dc19b4453f304c4e2fce5b3", size = 458209, upload-time = "2026-08-20T09:11:35.086Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b7/21ec24e28f98554f727ba78a8703009d44ddc8946a91715743e574ed3f01/fastar-0.12.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:6109ec55528a975ab3644dc1c9ccccb2c2315daa66ca34f54e1e3dca60afa757", size = 698704, upload-time = "2026-08-20T09:09:58.576Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f2/9e570204757c36d3ef1c94012294b1921a4c51af55da4684f206d88c09df/fastar-0.12.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:6e94e2881c3aa53da5d9161e2e64c0d698c66506a62024d5900943098220ebc7", size = 626785, upload-time = "2026-08-20T09:09:40.933Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d1/dfaf600497cdd4ddf3942c188d27171689f370d6ea2156b7646c606be8a0/fastar-0.12.0-cp315-cp315-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:682c531ac174d63919374eaab6fca91f92432cbf6a2262acb72719ba2e2a694d", size = 857172, upload-time = "2026-08-20T09:09:06.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/551b13387ae7ce88f165e7201757f031309a0cc9226663245096fba40554/fastar-0.12.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbf3d5bfd73516b506a916f6809b90a4ad73ff5840c0af6cbe0142417a03b014", size = 755384, upload-time = "2026-08-20T09:07:36.044Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/cb/b8f2f3572e0ec95ca9f0eaf6889e6d7da65782461b5a983379f833d6a453/fastar-0.12.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fbeb5fce858248d6b9b1fbef12c3e14d174432728c6e6eb1e2a63447432571c2", size = 750165, upload-time = "2026-08-20T09:07:53.779Z" },
+    { url = "https://files.pythonhosted.org/packages/34/66/71d24540a462eb5dbff8993dcf674844ae8355b8f5ea63195c10207c10a0/fastar-0.12.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45164f7138613b76918101ea28842cb69c10ff441c1ba2d56d7c6b28053f28e2", size = 916891, upload-time = "2026-08-20T09:08:12.202Z" },
+    { url = "https://files.pythonhosted.org/packages/84/b6/fc72480b7771ee14541b04ece4f94327a6522883ca51ebf46d9112723486/fastar-0.12.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e71715c64695bc80fd8fed2a82af30acb49b6bf085c06876cbfc2116b53cc7c", size = 808828, upload-time = "2026-08-20T09:08:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/88/1e/0cb98e45845e442cb04b4dcc5d3a149184b188ec41425960fec62ee140b9/fastar-0.12.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8056fb0f3ff2213eb00234d32b2d701cd288b763d3430b67033a393b8d33b47", size = 809399, upload-time = "2026-08-20T09:09:23.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/00/e568dfd06fbb14a70f165a9972672dc21418edbf25590229e8fb2176cd19/fastar-0.12.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a843704912dc3b20e152743bd5fa3e225bf9cc23c34fea0debeceefead477e78", size = 874588, upload-time = "2026-08-20T09:08:30.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8a/83ebe531a4a6fc93511c719ce8e505a2b23711e9ac4bed627cd7950eeb60/fastar-0.12.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:b4a7b6ca4a04e269aa26533ca8bfd0c674e4ee7328b0d3d80d45ab979a7e613c", size = 966301, upload-time = "2026-08-20T09:10:17.137Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7c/8c37e19cc9248b35d1b13cb6d27828755e2b23be9dd06437b77b572c0a01/fastar-0.12.0-cp315-cp315-musllinux_1_2_armv7l.whl", hash = "sha256:883f1e06c0d9649a2e54b767b3384b47306098ea73be3ca288d562c4d73dbcaa", size = 1026601, upload-time = "2026-08-20T09:10:37.159Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ac/4fb738d3ab7ede5545ebf8205beae5c9e3fb97088b68b2c2103357349efd/fastar-0.12.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:74858c4648bdc4450a66f3d6ec16a4e61ba48c16c9898a88a061d3272f82c65b", size = 1063319, upload-time = "2026-08-20T09:10:57.318Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8e/c31c84446226f20a217bad3921528bd8214b714ab1aa634afb183c1d852d/fastar-0.12.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:b16451d5b50579e4eb7dc1761946bc6f6186df44fa84310a06f455c26eb4442e", size = 1019807, upload-time = "2026-08-20T09:11:16.731Z" },
+    { url = "https://files.pythonhosted.org/packages/02/46/a44dee8cbc14601a91fc1818ea3e172cd5db2cd9af55f29c866bcee4c22d/fastar-0.12.0-cp315-cp315-win32.whl", hash = "sha256:ad8185a7b379e5cd81ef65209d21db4c63e8a62bcaa2d17fe40a8e50fcb28427", size = 451911, upload-time = "2026-08-20T09:12:04.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e2/1feebd0c4e7ea7839f250a4ab77663d3a6149124a5ff6ee01859d788b6a3/fastar-0.12.0-cp315-cp315-win_amd64.whl", hash = "sha256:a2819b9061cee89da560156b77230d4ffe81e75b8f64b9732ca34d7bc546e49e", size = 483441, upload-time = "2026-08-20T09:11:47.052Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/32/a2eaddc9b4f63d1560d4467df586d427da52717e01e88d9a0202439c07c9/fastar-0.12.0-cp315-cp315-win_arm64.whl", hash = "sha256:a8a8130f236a5dc2ceab88486f77bbdd516d08dc949d0f04194305845cf44c19", size = 459131, upload-time = "2026-08-20T09:11:33.448Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/7f/cffe7bae35e9e80789396f03cae4e8c4c761c3bee6003d2e622f6c9d8d6b/fastar-0.12.0-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:6f25c1aa6d55a457d95dc2163bbc27942e1541ca6792d4bf323a922688b8597e", size = 696600, upload-time = "2026-08-20T09:10:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/75/5e28ef81c3fac04a8d04a1068399069e28e4dbc6df221254c3a75b43af4d/fastar-0.12.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:aeb69fe64537deec4902f45ad9634b85d44ebb42ee1a33725d6584e8d9b33927", size = 625371, upload-time = "2026-08-20T09:09:42.547Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/aa/234c34a70d5e9e30420f43a9bad7a0046593ce5d65c2452f147f0a65e86a/fastar-0.12.0-cp315-cp315t-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6a83ae278bcc718dd155219fbbd552a16bd8c178effc5021600c3be2806a01cf", size = 856582, upload-time = "2026-08-20T09:09:08.082Z" },
+    { url = "https://files.pythonhosted.org/packages/79/99/bd327da80d86309f6f5806cb3af70f91473d26fafe53f7cb646aaf35a4e5/fastar-0.12.0-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c048c732e3ca28a132732f83130ccdab58d9b27dd36bb26bdeb42c2d48827da9", size = 754890, upload-time = "2026-08-20T09:07:37.76Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/a72bf87d4a26ef1bc94fde3b4c37c97500c1db5e2431bbfba865fabd8eb2/fastar-0.12.0-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:613466f628667af03de8f914de58a07bfb3ee1bd0347e3532ec9790df92a1e72", size = 748828, upload-time = "2026-08-20T09:07:55.27Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/63/2880890777d680271115ff6b2e8b891069610463308e7779e0fa9c8d9e75/fastar-0.12.0-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f59d3243d8913db385ab822be8f111f188218ea73f9f14f5d70c869a33ff4d1", size = 917262, upload-time = "2026-08-20T09:08:14.243Z" },
+    { url = "https://files.pythonhosted.org/packages/08/06/b3293a2a8bf7bac81e848fcc1c67411a0770b186a3bfe5232ea6dac5e929/fastar-0.12.0-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b362e5404dab262e85f0d93bd950933a0935dac6a9f5f0516bba6c703c440ec", size = 808819, upload-time = "2026-08-20T09:08:49.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/0c0e9c1bc422272df07414d137d25eeb4bec8b3a8966c8e2b179967390fe/fastar-0.12.0-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d1e50c423cd064f29f11c98f6d995b8fa7df7bbc19f3fdb9f081859afd8e00b", size = 809620, upload-time = "2026-08-20T09:09:25.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/34/f10ca8db20176ee9e685da80fcdad2c79e66485ed025ee16881e8113d97f/fastar-0.12.0-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:6857a79691c5c033a31d76c62ad02f2c92d173a0e1fb2fac7fcb7ac686108bd3", size = 874739, upload-time = "2026-08-20T09:08:31.946Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a8/547881f35496d5b5b64f3e29552475d92d55d7bc213244bd7fb59938a116/fastar-0.12.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:3053bb800b5375fbca8f96d256654ae3489c439f1b55766896d1c703d8281804", size = 965821, upload-time = "2026-08-20T09:10:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/a4376b6e70e6ca8909b8788b6e0ccc55cb9f0ada4c2bf7f95490d06659fe/fastar-0.12.0-cp315-cp315t-musllinux_1_2_armv7l.whl", hash = "sha256:067094312cbea82ef2efa3999dc31318ac539805965c9505d99654f01775cac1", size = 1025655, upload-time = "2026-08-20T09:10:38.892Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ab/48e90600f5c08e7869c8cbd346cb9cf846414f85ca1f9e7aa6976222c6b5/fastar-0.12.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:f69400ebb83a8d754aa7735165c12f8029ac577c3c08eb6d174eedc5901b7cb2", size = 1063028, upload-time = "2026-08-20T09:10:58.989Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/e113f8aebfd874d3c78945a094fc803ca295b92e12dc0d80ec81e2a7701f/fastar-0.12.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7d875d99946a11538f7ecb183f0a885d1d0a0495a6f1d6d2aa1de9b5fe6e5e9d", size = 1019546, upload-time = "2026-08-20T09:11:18.523Z" },
+    { url = "https://files.pythonhosted.org/packages/51/45/72c2bf5ae3386407009fe51c40e548e41f70181bbe34a6477bb6078be047/fastar-0.12.0-cp315-cp315t-win32.whl", hash = "sha256:39dad3351f1399cd28e2e649b6651299ef857df6c745e598b00b4167dcf93dbc", size = 449932, upload-time = "2026-08-20T09:12:10.589Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/0adeb47b838c62ebd78bdf11ee2255e6e205ea176f9147978efa022ef855/fastar-0.12.0-cp315-cp315t-win_amd64.whl", hash = "sha256:00cda9a3f11871261a4e77a3b8f0eede85c9730fb7516811bcbcf96a2bb3b75b", size = 482858, upload-time = "2026-08-20T09:11:53.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/b2ce5a79c57150d36aa8e0514dd65999ea76f091242aba93c403cd20e491/fastar-0.12.0-cp315-cp315t-win_arm64.whl", hash = "sha256:e8e0fb057b5c271f46f3300b539b0d3dab8c8cb2515205a37c818c2f68d16806", size = 458287, upload-time = "2026-08-20T09:11:36.952Z" },
 ]
 
 [[package]]
@@ -446,6 +478,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
@@ -490,6 +535,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -707,7 +777,7 @@ dependencies = [
 dev = [
     { name = "beautifulsoup4" },
     { name = "dateparser" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pytest" },
     { name = "pytest-run-parallel" },
 ]
@@ -731,7 +801,7 @@ requires-dist = [
 dev = [
     { name = "beautifulsoup4", specifier = ">=4.15" },
     { name = "dateparser", specifier = ">=1.4.2" },
-    { name = "httpx", specifier = ">=0.28" },
+    { name = "httpx2", specifier = ">=2.12" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-run-parallel", specifier = ">=0.10" },
 ]
@@ -1394,6 +1464,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,15 +1540,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.3"
+version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c", size = 79859, upload-time = "2026-08-13T16:50:01.323Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
# https://httpx2.pydantic.dev
FastAPI may continue to use `httpx` under the hood, but our code has been upgraded to the more active and better-supported `httpx2`.
https://httpx2.pydantic.dev/migration/

---
@mdlama See minor changes to `server/plugins/qubes/`